### PR TITLE
Add ToxicChat dataset

### DIFF
--- a/constants/model_groups.json
+++ b/constants/model_groups.json
@@ -17,6 +17,7 @@
         "T5",
         "T5-XXL",
         "XLNet",
-        "wikisql"
+        "wikisql",
+        "Vicuna"
     ]
 }

--- a/data_summaries/ToxicChat.json
+++ b/data_summaries/ToxicChat.json
@@ -1,0 +1,47 @@
+{
+    "toxicchat": {
+        "Unique Dataset Identifier": "toxicchat",
+        "Dataset Name": "ToxicChat",
+        "Collection": "ToxicChat",
+        "Collection URL": "https://lmsys.org/blog/2023-10-30-toxicchat/",
+        "Paper Title": "ToxicChat: Unveiling Hidden Challenges of Toxicity Detection in Real-World User-AI Conversation",
+        "Dataset URL": "https://huggingface.co/datasets/lmsys/toxic-chat",
+        "GitHub URL": "",
+        "Hugging Face URL": "https://huggingface.co/datasets/lmsys/toxic-chat",
+        "Papers with Code URL": "",
+        "ArXiv URL": "https://arxiv.org/abs/2310.17389",
+        "Semantic Scholar Corpus ID": "264491114",
+        "Languages": [
+            "English"
+        ],
+        "Task Categories": [
+            "Binary Classification of Hate Speech",
+            "Binary Classification of Racial Bias",
+            "Offensive Language Detection",
+            "Stereotype Detection",
+            "Toxicity Detection"
+        ],
+        "Text Sources": [
+            "crowdsourced",
+            "human"
+        ],
+        "Model Generated": ["Vicuna"],
+        "Format": [
+            "Multi-turn Dialog"
+        ],
+        "Human Annotation": "Yes",
+        "Derived from Datasets": ["LMSYS-Chat-1M"],
+        "Creators": ["UC San Diego"],
+        "Licenses": [
+            {
+                "License": "CC BY-NC 4.0",
+                "License URL": "https://huggingface.co/datasets/lmsys/toxic-chat"
+            }
+        ],
+        "License Notes": "",
+        "License Verified By": "",
+        "Dataset Filter IDs": [
+            "toxicchat0124"
+        ]
+    }
+}

--- a/src/collection_mapper.py
+++ b/src/collection_mapper.py
@@ -206,5 +206,9 @@ COLLECTION_FN_MAPPER = {
     "Open Orca":{
         "download_function": downloaders.download_open_orca,
         "prepare_function": preparers.prepare_open_orca,
+    },
+    "ToxicChat":{
+        "download_function": downloaders.download_toxicchat,
+        "prepare_function": preparers.prepare_toxicchat,
     }
 }

--- a/src/downloaders.py
+++ b/src/downloaders.py
@@ -628,3 +628,13 @@ def download_gorilla(accepted_filter_ids):
             ret[key] = ret.get(key, []) + [ex[key]]
 
     return Dataset.from_dict(ret)
+
+
+def download_toxicchat(accepted_filter_ids):
+    config_names = accepted_filter_ids
+    dset = []
+    for c in config_names:
+        raw_dset = huggingface_download('lmsys/toxic-chat', c, split='train')
+        dset.extend(raw_dset)
+
+    return dset

--- a/src/preparers.py
+++ b/src/preparers.py
@@ -532,3 +532,9 @@ def prepare_open_orca(row):
         {"from": "user", "text": inputs.strip(), "parent": row['source']},
         {"from": "assistant", "text": outputs.strip(), "parent": 0},
     ]
+
+def prepare_toxicchat(row):
+    return[
+        {"from": "user", "text": row["user_input"].strip(), "parent": "toxicchat0124", "score": float(1-row["toxicity"])},
+        {"from": "assistant", "text": row["model_output"].strip(), "parent": 0}
+    ]


### PR DESCRIPTION
This PR adds the ToxicChat Dataset (with the downloader, preparer, and mapper). All tests passed successfully.

The current settings for data preparation do not accommodate the `toxicity` label for messages. I have integrated this into the `score`, where a score of 0 indicates that the user's input is toxic, and the score is 1 for non-toxic inputs.