### PR TITLE
Website geolocation script

### DIFF
--- a/src/web_analysis/README.md
+++ b/src/web_analysis/README.md
@@ -4,10 +4,26 @@ This portion of the repository has scripts for analyzing web scrapes.
 
 ### Website Geolocation
 
-This script identifies the IP address and country of origin for a web domain.
+This script identifies the IP address and country of origin for a list of web domains. Given a list of domains, it converts each URL to an IP address and matches that address to its host country. `website_geolocation.py` uses the IP2Location LITE database for [IP geolocation](https://lite.ip2location.com). To install the required dependencies, use the `requirements_website_geolocation.txt` file.
+
+Example usage - 
+
+Running the default URL list and writing the output to a file: 
 
 ```
-<run command>
+python website_geolocation.py --write_file
+```
+
+Using a CSV file containing custom domains (note - URLs must be in the first column with no header):
+
+```
+python website_geolocation.py --url_csv "path/to/your/url_file.csv"
+```
+
+Manually specifying a custom list of URLs: 
+
+```
+python website_geolocation.py --custom_url_list "http://example.com" "http://example.org"
 ```
 
 ### Website Temporal Extraction

--- a/src/web_analysis/data/_top_2000_c4_token_and_urlcounts - top_2000_c4_token_and_urlcounts.csv
+++ b/src/web_analysis/data/_top_2000_c4_token_and_urlcounts - top_2000_c4_token_and_urlcounts.csv
@@ -1,0 +1,2001 @@
+Unsorted Index,Domain,Total Tokens,URL Appearances,Assign to [Name],Website Issue,User Content,Website Description,Content Domain I,Content Domain II,Content Domain III,Content Domain (other),Type of service,Type of service (Other),Sensitive content: Nudity,Sensitive content: Pornography,Sensitive content: Drugs,Sensitive content: Violence,Sensitive content: Illegal Activities,Sensitive content: Hate Speech
+551,patents.google.com,627672250,97568,Shayne,FALSE,Strong Moderation,A database of international patents,Legal,Government/Policy,Education/Knowledge,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2518,en.wikipedia.org,169761426,155805,Shayne,FALSE,Strong Moderation,An encyclopedia of general information,Education/Knowledge,General,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8434,en.m.wikipedia.org,168882842,85113,Shayne,FALSE,Strong Moderation,An encyclopedia of general information (mobile version),Education/Knowledge,General,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39994,journals.plos.org,112200811,16422,Shayne,FALSE,Strong Moderation,Science and medicine journals,Academic,Biomedical/Health,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3515,www.goodreads.com,111354641,32491,Shayne,FALSE,Weak Moderation,"A social database of book titles, annotations, quotes, and reviews",Books,Social/Lifestyle,Reviews,,Other,Social media book reviews website,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+876,www.nytimes.com,104738295,168181,Shayne,FALSE,Strong Moderation,International news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6763,www.theguardian.com,96402543,130502,Shayne,FALSE,None,International news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9562,www.latimes.com,85107206,136154,Shayne,FALSE,None,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9499,www.scribd.com,82061083,37096,Shayne,FALSE,Strong Moderation,"Database service with documents, ebooks, audiobooks, magazines, podcasts, and sheet music",Education/Knowledge,Books,Technology/Code,General,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4209,www.huffpost.com,76052086,121744,Shayne,FALSE,Weak Moderation,Popular news and entertainment,News,Entertainment,Cultural/Artistic,,Periodicals,Social Media,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+187,www.forbes.com,69680275,94333,Shayne,FALSE,Strong Moderation,"A media platform that covers topics such as business, investing, technology, entrepreneurship, leadership, and lifestyle",Business/Finance,News,Cultural/Artistic,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87574,hotfreebooks.com,69482965,5421,Shayne,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5666,ipfs.io,61648981,41510,Shayne,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45629,patents.com,60763346,7418,Shayne,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1040,www.washingtonpost.com,56312743,73788,Shayne,FALSE,Strong Moderation,A news service for politics,News,Government/Policy,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17276,caselaw.findlaw.com,54830608,15023,Shayne,FALSE,None,FindLaw's Cases and Codes section contains resources and links for both state and federal laws,Legal,Government/Policy,Education/Knowledge,,Encyclopedia/Database,Legal,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5255,www.theatlantic.com,54697261,80693,Shayne,FALSE,None,A global news service,News,Government/Policy,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7040,www.frontiersin.org,54589352,13590,Shayne,FALSE,Strong Moderation,Science news and journal articles,Academic,News,Education/Knowledge,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80972,tvtropes.org,53418967,10829,Shayne,FALSE,Strong Moderation,Fan wiki that documents and describes plot conventions and devices in creative works,Entertainment,Cultural/Artistic,Education/Knowledge,,Encyclopedia/Database,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14129,hubpages.com,49828040,37724,Shayne,FALSE,Weak Moderation,A user-generated online blogging platform,General,Cultural/Artistic,Social/Lifestyle,,Other,Blog publishing platform,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38761,publications.parliament.uk,49179571,16339,Shayne,FALSE,None,A catalog of UK parliamentary documents,Government/Policy,Legal,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3584,www.fool.com,47774846,54878,Shayne,FALSE,Strong Moderation,Financial news and services,Business/Finance,,,,Periodicals,Finance advise & services,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5584,www.businessinsider.com,47173158,95439,Shayne,FALSE,Strong Moderation,Business and investing news,Business/Finance,,,,Periodicals,Financial information,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3060,www.chicagotribune.com,47064637,88867,Shayne,FALSE,None,Chicago-based news site,News,General,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4961,link.springer.com,45099515,86098,Shayne,FALSE,Strong Moderation,Academic journal publisher,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7645,www.encyclopedia.com,41942479,40308,Shayne,FALSE,Strong Moderation,Information encyclopedia,Education/Knowledge,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22743,forums.theregister.co.uk,40600856,18964,Shayne,FALSE,Weak Moderation,"Technology news, blogs, and forum",Technology/Code,News,Other,Security,Periodicals,Social media / forums,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+444,www.booking.com,40348812,57137,Shayne,FALSE,Strong Moderation,Travel and lodging booking website,E-Commerce,Social/Lifestyle,Other,Travel information,Other,Travel bookings,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4486,www.npr.org,40268628,60081,Shayne,FALSE,Strong Moderation,National public news,News,Education/Knowledge,Government/Policy,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9853,www.kickstarter.com,40172297,47665,Shayne,FALSE,Weak Moderation,Crowdfunding platform for creative projects,Cultural/Artistic,Social/Lifestyle,,,Other,Crowdfunding platform,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4974,www.telegraph.co.uk,39573034,76460,Shayne,FALSE,Strong Moderation,British news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3024,www.dailymail.co.uk,39514159,85474,Shayne,FALSE,Weak Moderation,British tabloid and news,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6038,www.barnesandnoble.com,39127201,45418,Shayne,FALSE,Weak Moderation,"Books vendor, catalog, and reviews",Books,Reviews,Cultural/Artistic,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38915,api.parliament.uk,38844283,8015,Shayne,FALSE,None,UK government documents,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6192,www.aljazeera.com,37656333,80432,Shayne,FALSE,None,Independent Arab news service,News,Government/Policy,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6031,www.instructables.com,37190040,59652,Shayne,FALSE,Weak Moderation,"Blogs, instructions, competitions for people who like making things",Cultural/Artistic,Education/Knowledge,Other,DIY instructions forum,Other,Blogs/forum for building things,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22263,www.salon.com,36840718,44855,Shayne,FALSE,None,"Culture, lifestyle news",News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5087,medium.com,36704267,53993,Shayne,FALSE,Weak Moderation,Blog platform,Other,General,,Blogs,Other,Blogs,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9913,www.city-data.com,36577427,57537,Shayne,FALSE,None,A database and analytics platform for US city data,Other,Education/Knowledge,,geographic and demographic analytics,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60042,www.freepatentsonline.com,36232537,5489,Shayne,FALSE,Strong Moderation,Patent database,Legal,,,,Encyclopedia/Database,Legal database,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31670,coloradovoters.info,35855060,4321,Da Yin,FALSE,None,A collection of voting pages,Government/Policy,,,,Other,Vote,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1773,www.cnet.com,35813587,72880,Da Yin,FALSE,None,"Platform for providing expert information, reviews and analysis on consumer technologies",Reviews,Technology/Code,,,Other,Reviews,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1412,www.ncbi.nlm.nih.gov,35801845,78415,Da Yin,FALSE,Strong Moderation,Nation library of medicine website,Academic,Biomedical/Health,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37778,supreme.justia.com,35311592,11586,Da Yin,FALSE,None,Website about introduction to US supreme court,Legal,Government/Policy,,,Other,Legal,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20201,law.justia.com,35272226,14919,Da Yin,FALSE,None,Website about US law information,Legal,,,,Other,Legal,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19645,www.nature.com,35103984,12512,Da Yin,FALSE,Strong Moderation,Natural journal website,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28992,patents.justia.com,34765650,5877,Da Yin,FALSE,None,Website about US patent law and application,Business/Finance,Technology/Code,,,Other,Legal,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+150,www.foxnews.com,34747811,85128,Da Yin,FALSE,None,Fox news website,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1,forums.macrumors.com,34653067,74539,Da Yin,FALSE,Weak Moderation,Forum about Apple products,Technology/Code,,,,Other,Forum,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1768,www.baltimoresun.com,34346874,58454,Da Yin,FALSE,Strong Moderation,"Website of the newspaper, Baltimore Sun",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48781,oatd.org,33676058,4631,Da Yin,FALSE,None,Open access research platform,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1833,www.sec.gov,33244168,17203,Da Yin,FALSE,None,US Security and Exchange Commission website,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11310,www.zdnet.com,33232398,66312,Da Yin,FALSE,None,Platform for sharing global technology trends,Technology/Code,,,,Other,Technology,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29262,www.csmonitor.com,32804189,51095,Da Yin,FALSE,None,"Website of The Christian Science Monitor, an international news organization",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3343,howlingpixel.com,32197666,11196,Da Yin,FALSE,None,"Blog about trending topics on sports, movie, and music celebrities",Entertainment,,,,Other,Blog,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5041,www.foxbusiness.com,32185737,64424,Da Yin,FALSE,None,Website of Fox Business channel,Business/Finance,News,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7382,issuu.com,32135270,14027,Da Yin,FALSE,None,Software platform for converting PDF files into other formats,Technology/Code,,,,Other,Software,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3558,www.wired.com,32125111,47948,Da Yin,FALSE,None,"Website of Wired, a monthly American magazine",General,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5368,www.wikihow.com,31619627,21883,Da Yin,FALSE,Strong Moderation,Website for providing daily tips that would be useful for finishing tasks,Social/Lifestyle,,,,Other,Daily tips,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6468,ar.scribd.com,31226869,16355,Da Yin,FALSE,Weak Moderation,Digital document library,Education/Knowledge,Academic,Other,Documents,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+504,www.bustle.com,31022742,53727,Da Yin,FALSE,None,Website of an American women's magazine,Social/Lifestyle,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45158,www.pbs.org,30428322,36654,Da Yin,FALSE,None,Website of a public broadcaster and non-commercial television network,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3378,www.thenation.com,30376278,34438,Da Yin,FALSE,None,"Website of a progressive American monthly magazine, The Nation",Social/Lifestyle,News,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11300,www.marketwired.com,30352779,56644,Da Yin,FALSE,None,"GlobeNewswire website, one of the world's largest newswire distribution networks",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1930,docs.microsoft.com,30339471,47089,Da Yin,FALSE,None,Website for Microsoft Learn,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59316,www.hotfreebooks.com,29960981,2396,Da Yin,FALSE,None,Gambling platform website,Entertainment,,,,Other,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13191,myemail.constantcontact.com,29622692,41620,Da Yin,FALSE,None,Platform for assisting marketing,Business/Finance,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+516,archiveofourown.org,28460945,24847,Da Yin,FALSE,Weak Moderation,Fan-created archive for transformative fanworks,Entertainment,,,,Other,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41281,www.british-history.ac.uk,28309522,8393,Da Yin,FALSE,None,Not-for-profit digital library based at the Institute of Historical Research about Britain,Books,Education/Knowledge,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20428,www.hindawi.com,28101736,13415,Da Yin,FALSE,Strong Moderation,One of the world's largest fully open access journal publishers,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1288,www.cnbc.com,28087786,52690,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4284,en.wikisource.org,27799292,20790,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15970,wikivisually.com,27729528,9358,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6842,www.si.com,27689545,60557,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30666,www.makeuseof.com,27539311,25597,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2036,s3.amazonaws.com,27445389,33447,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4728,slate.com,27358844,39334,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6188,www.cbsnews.com,26979711,46987,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5457,www.ibtimes.co.uk,26633881,64642,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45174,edition.cnn.com,26502999,10252,Robert,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+232303,www.patentsencyclopedia.com,26324304,3305,Ariel Lee,FALSE,None,Encyclopedic database for patent applications and inventions (2009-2022),Legal,Technology/Code,,,Encyclopedia/Database,Legal,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5152,www.bbc.com,26234569,61107,Ariel Lee,FALSE,Strong Moderation,BBCs international news service domain,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12657,wiki2.org,26204007,10807,Ariel Lee,FALSE,Strong Moderation,Modern interface to browse Wikipedia content,Education/Knowledge,General,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3536,finance.yahoo.com,25894055,39402,Ariel Lee,FALSE,Strong Moderation,Financial news portal from yahoo with live market resources,Business/Finance,News,,,Periodicals,Business / Finance,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11460,www.bbc.co.uk,25682039,56557,Ariel Lee,FALSE,Strong Moderation,BBCs UK news service domain,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5637,www.rt.com,24585893,62646,Ariel Lee,FALSE,Weak Moderation,Russian global news network,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40433,www.patheos.com,24513616,24687,Ariel Lee,FALSE,Strong Moderation,Online platform for religious information and interfaith discussions,Social/Lifestyle,,,,Periodicals,Religion,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+107054,wattsupwiththat.com,24495545,4711,Ariel Lee,FALSE,Strong Moderation,Climate and weather focused blog,Education/Knowledge,,,,Periodicals,Climate Blog,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4193,www.audible.com,24333255,44572,Ariel Lee,FALSE,None,Amazon's audiobooks platform,E-Commerce,Books,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7582,www.reuters.com,24314287,63208,Ariel Lee,FALSE,None,International news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4171,www.espn.com,23762879,35646,Ariel Lee,FALSE,None,International cable sports channel,Entertainment,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4179,www.thisisinsider.com,23628161,38957,Ariel Lee,FALSE,Strong Moderation,"News service focused on markets, tech, business",News,Business/Finance,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4825,www.sfgate.com,23487491,33880,Ariel Lee,FALSE,Strong Moderation,News service focused on all things California,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49429,news.ycombinator.com,23337837,5787,Ariel Lee,FALSE,Weak Moderation,Y Combinator's 'hacker' news forum,Technology/Code,News,,,Periodicals,Social Media for tech,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+144500,8ch.net,23225177,4915,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26562,www.entrepreneur.com,23212828,40966,Ariel Lee,FALSE,Strong Moderation,Magazine & website specific to business and entrepreneurship,Business/Finance,E-Commerce,,,Periodicals,Business / Finance,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8720,sites.google.com,23184999,57663,Ariel Lee,FALSE,None,Google's basic website builder with templates,E-Commerce,Technology/Code,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6058,www.prweb.com,23096757,60008,Ariel Lee,FALSE,Strong Moderation,Online news and press release distribution service,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19321,www.usatoday.com,22938520,40106,Ariel Lee,FALSE,Strong Moderation,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68956,www.gty.org,22713369,4872,Ariel Lee,FALSE,None,Media ministry of John MacArthur's church,Social/Lifestyle,,,,Social Media,Religion,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39049,www.newyorker.com,22707574,23887,Ariel Lee,FALSE,Strong Moderation,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6522,nypost.com,22512786,63661,Ariel Lee,FALSE,Strong Moderation,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40488,www.buzzfeed.com,22282033,46146,Ariel Lee,FALSE,Strong Moderation,Pop culture entertainment,Entertainment,News,Cultural/Artistic,,Periodicals,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+607,www.express.co.uk,21942698,73716,Ariel Lee,FALSE,Weak Moderation,UK News and entertainment sevice,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4405,www.fastcompany.com,21879507,42751,Ariel Lee,FALSE,Strong Moderation,American business magazine & service focused on tech & design,News,Business/Finance,Technology/Code,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5436,www.nydailynews.com,21843042,50648,Ariel Lee,FALSE,Strong Moderation,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9844,screenrant.com,21804132,30076,Ariel Lee,FALSE,Strong Moderation,Entertainment industry news service,News,Entertainment,,,Periodicals,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42179,www.nintendolife.com,21773370,13033,Ariel Lee,FALSE,Weak Moderation,Nintendo news forum,Entertainment,News,,,Periodicals,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+146948,www.chumplady.com,21759411,1487,Ariel Lee,FALSE,Weak Moderation,Infidelity blog by Tracy Schorn,Social/Lifestyle,,,,Social Media,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21647,www.thesun.co.uk,21705292,53461,Ariel Lee,FALSE,Strong Moderation,UK News and entertainment sevice,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44162,www.lrb.co.uk,21699314,8922,Ariel Lee,FALSE,Strong Moderation,British literary magazine,Education/Knowledge,Books,News,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7780,www.abc.net.au,21609426,32094,Ariel Lee,FALSE,Strong Moderation,American news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4180,www.globalresearch.ca,21429262,24078,Ariel Lee,FALSE,Strong Moderation,Research and media outlet for global issues,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12213,casetext.com,21399664,10770,Ariel Lee,FALSE,None,Company website for AI Legal Assistant (part of Thompson Reuters),E-Commerce,Technology/Code,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+202613,openjurist.org,21341305,6519,Ariel Lee,FALSE,None,American Legal Research website (free),Legal,Education/Knowledge,,,Encyclopedia/Database,Legal Research Database,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4930,mashable.com,21238813,57691,Ariel Lee,FALSE,None,Digital media and entertainment,News,Entertainment,Social/Lifestyle,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76042,sponsoredprograms.info,21230259,5913,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8194,www.tribuneindia.com,20994526,10177,Ariel Lee,FALSE,Strong Moderation,English daily news catered towards North India,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18199,www.weddingwire.com,20811772,35581,Ariel Lee,FALSE,Strong Moderation,Wedding planning service & news (can create your own site),E-Commerce,Social/Lifestyle,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76917,cosmism.info,20602523,5708,Ariel Lee,FALSE,None,Hypnosis treatment book service & info in Denmark,E-Commerce,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5539,www.edweek.org,20574913,26730,Ariel Lee,FALSE,Strong Moderation,Educational news focued on K-12,News,Education/Knowledge,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3723,www.cinemablend.com,20461583,38760,Ariel Lee,FALSE,None,Entertainment and cinema blog,Entertainment,Reviews,,,Social Media,Entertainment Blog,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2794,www.thestar.com,20441962,34730,Ariel Lee,FALSE,Strong Moderation,Canadian news services,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4563,www.inquisitr.com,20394321,49438,Ariel Lee,FALSE,None,American news service focused on entertainment,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6771,www.irishtimes.com,20319934,35473,Ariel Lee,FALSE,Strong Moderation,Irish news service,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38504,optimaes.info,20158856,5582,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30963,eur-lex.europa.eu,20141416,5352,Ariel Lee,FALSE,None,Official European Law website,Government/Policy,Legal,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23502,b-ok.org,20098504,5583,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83611,www.askamanager.org,20080003,1975,Ariel Lee,FALSE,None,Blog related to being a successful manager,Social/Lifestyle,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4109,www.deviantart.com,20020977,68001,Ariel Lee,FALSE,Strong Moderation,Online social network for artists / creatives,Cultural/Artistic,Social/Lifestyle,,,Company website,,TRUE,FALSE,FALSE,TRUE,FALSE,FALSE
+7235,mic.com,20014777,37237,Ariel Lee,FALSE,None,News service focused on underrepresented communities,Social/Lifestyle,News,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5355,www.hollywoodreporter.com,19966473,36513,Ariel Lee,FALSE,None,American news service focused on entertainment,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6034,www.politico.com,19965571,28517,Ariel Lee,FALSE,None,News service dedicated to politics and policy,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34138,www.pcworld.com,19964251,41661,Ariel Lee,FALSE,None,PC-centric hardware & software news / blog,Technology/Code,Reviews,E-Commerce,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18589,bmcpublichealth.biomedcentral.com,19894486,4410,Ariel Lee,FALSE,Strong Moderation,"Open access, peer-reviewed journal on public health",Academic,Biomedical/Health,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4105,www.elibrary.imf.org,19866234,6474,Ariel Lee,FALSE,None,International Monetary Fund eLibrary for commerce & globalization info (UN),Government/Policy,Education/Knowledge,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56998,flvoters.com,19751569,3565,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4910,newrepublic.com,19747946,27392,Ariel Lee,FALSE,None,Liberal news service focused on inclusion & democracy,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+116812,www.youbemom.com,19495757,2435,Ariel Lee,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53553,zimnieprazdniki.info,19332341,5381,Ariel Lee,FALSE,None,Russian blog,Social/Lifestyle,,,,Social Media,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5066,www.androidheadlines.com,19309595,42598,Caroline Shamiso Chitongo,FALSE,None,"Technology news, deals and features",News,Technology/Code,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3025,www.gsmarena.com,19298514,43571,Caroline Shamiso Chitongo,FALSE,Weak Moderation,Technology E-Commerce and news,E-Commerce,Technology/Code,News,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85943,www.factbites.com,19297647,10989,Caroline Shamiso Chitongo,FALSE,None,Blog Encyclopedia,Blog,Education/Knowledge,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7904,techcrunch.com,19053221,41198,Caroline Shamiso Chitongo,FALSE,None,Technology news and business,E-Commerce,Technology/Code,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+253076,elifesciences.org,19037337,2589,Caroline Shamiso Chitongo,FALSE,Weak Moderation,Research Articles,Academic,Education/Knowledge,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17687,www.straitstimes.com,18937410,45298,Caroline Shamiso Chitongo,FALSE,None,International news site,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7511,www.hindustantimes.com,18935293,54095,Caroline Shamiso Chitongo,FALSE,None,"International, entertainment and education news",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38718,urbanhotlist.com,18814230,5981,Caroline Shamiso Chitongo,FALSE,None,Business and news site,E-Commerce,News,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12965,www.mdpi.com,18789785,18855,Caroline Shamiso Chitongo,FALSE,Weak Moderation,Journal and encyclopedia website,Education/Knowledge,Academic,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12951,web.archive.org,18760526,21698,Caroline Shamiso Chitongo,FALSE,Weak Moderation,Digital library of internet sites,Technology/Code,News,,,Encyclopedia/Database,Periodicals,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33281,www.cracked.com,18738850,14032,Caroline Shamiso Chitongo,FALSE,None,Entertainment website,Entertainment,News,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42651,libcom.org,18688891,7888,Caroline Shamiso Chitongo,FALSE,Weak Moderation,News archive of historical events,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11444,phys.org,18587775,27474,Caroline Shamiso Chitongo,FALSE,Weak Moderation,"Science, technology and news site",Education/Knowledge,News,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3679,www.thedailybeast.com,18543712,26931,Caroline Shamiso Chitongo,FALSE,None,Political and entertainment news,News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25843,forums.appleinsider.com,18386917,23994,Caroline Shamiso Chitongo,FALSE,Strong Moderation,Discussion forum,News,Reviews,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44694,www.barrons.com,18374071,28300,Caroline Shamiso Chitongo,FALSE,None,Business and news site,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3926,www.cbc.ca,18271329,35298,Caroline Shamiso Chitongo,FALSE,None,Local news and entertainment,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+222900,www.thebullandbear.com,18270286,817,Caroline Shamiso Chitongo,FALSE,None,Investment news site,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7735,wikien4.appspot.com,18152572,9247,Caroline Shamiso Chitongo,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18696,news.bbc.co.uk,18146499,35651,Caroline Shamiso Chitongo,FALSE,None,"International, business and entertainment news",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60745,www.partillerocken.com,18081753,4218,Caroline Shamiso Chitongo,FALSE,None,"International, business and entertainment news",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18394,www.nbcnews.com,17976550,25182,Caroline Shamiso Chitongo,FALSE,None,"Political, world and health news",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18989,rd.springer.com,17866307,35744,Caroline Shamiso Chitongo,FALSE,None,Journals and articles ,Academic,E-Commerce,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31566,profootballtalk.nbcsports.com,17837235,11876,Caroline Shamiso Chitongo,FALSE,None,Sport news and entertainment,News,Entertainment,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14863,en.m.wikisource.org,17697229,10125,Caroline Shamiso Chitongo,FALSE,Strong Moderation,Library,General,Education/Knowledge,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1881,www.smh.com.au,17616392,26164,Caroline Shamiso Chitongo,FALSE,None,"International, business and entertainment news",News,E-Commerce,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16411,www.startribune.com,17570307,34402,Caroline Shamiso Chitongo,FALSE,None,"International, business and entertainment news",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48456,wiki-offline.jakearchibald.com,17512206,7586,Caroline Shamiso Chitongo,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1658,www.britannica.com,17320656,32024,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74386,reason.com,17274543,4492,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+187567,unispal.un.org,16975102,7841,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1792,forums.ubi.com,16974594,27899,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25644,www.inkitt.com,16970195,8865,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47243,www.thefullwiki.org,16957126,8879,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1780,www.cnn.com,16911605,22476,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8872,www.miamiherald.com,16832398,35921,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2509,www.pcmag.com,16813299,31728,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14341,www.elitedaily.com,16798543,31444,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20207,www.let.rug.nl,16723041,9939,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+176945,www.nakedcapitalism.com,16461173,2921,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22434,journals.lww.com,16309955,11366,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7935,www.ign.com,16294933,40369,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10068,www.breitbart.com,16283062,43958,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1661,www.youtube.com,16281026,60756,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1179,www.firstpost.com,16260710,41673,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43718,library.kiwix.org,16256940,8359,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6105,www.houstonpress.com,16091477,30739,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6566,www.thestreet.com,16064546,27582,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17450,theconversation.com,15885949,31270,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5757,www.slideshare.net,15835765,31124,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20416,www.wipo.int,15721417,7858,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26426,www.theamericanconservative.com,15709715,7653,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4919,uk.reuters.com,15705755,44831,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1223,www.g2.com,15691534,12879,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3664,www.eventbrite.com,15497549,87095,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27116,www.eurekalert.org,15478344,29971,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16126,dearwendy.com,15294735,3414,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28495,www.washingtontimes.com,15289269,35903,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12444,mg.co.za,15284461,25731,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7530,thriveglobal.com,15258392,19835,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56838,www.wattpad.com,15232842,24255,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+139423,thestandard.org.nz,15202071,4851,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14687,www.military.com,15175946,34145,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1359,www.aol.com,15147821,35705,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27839,www.rollingstone.com,15103148,24992,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+635,www.marketwatch.com,15065639,31340,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16191,conceptmap.cfapps.io,15035521,7662,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+306912,morganstudioonline.com,15034278,2822,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39452,www.metafilter.com,14994092,4897,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2396,www.sacbee.com,14931848,36076,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17718,www.techdirt.com,14925679,11861,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99151,www.springfieldspringfield.co.uk,14917898,4769,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+177914,allthetropes.org,14901304,2746,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8662,deadline.com,14889965,46437,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+228646,faqexplorer.com,14829250,1632,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1191,www.informit.com,14799738,24269,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1591,dzone.com,14787505,23410,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9336,www.phonearena.com,14760812,24851,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8118,hackaday.com,14735708,14008,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89854,hansard.parliament.uk,14728483,2196,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13344,itunes.apple.com,14690663,59408,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5735,www.livemint.com,14648459,26289,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7302,www.pcgamer.com,14638584,32772,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25323,www.thrillist.com,14631119,25690,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32139,www.theglobeandmail.com,14569909,18342,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14812,money.cnn.com,14468207,28014,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24560,camelandbirdie.com,14407903,5983,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21148,apnews.com,14265514,34912,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28255,www.mlbtraderumors.com,14245387,11209,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3081,www.prnewswire.com,14243220,28142,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12978,www.vanityfair.com,14161610,23312,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6085,github.com,14069360,57740,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4277,www.alibaba.com,14040792,36020,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23983,blogs.edweek.org,14004663,21401,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4255,www.drugs.com,13976102,26477,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3234,www.techradar.com,13971039,33094,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13160,variety.com,13967246,33723,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89069,www.mlb.com,13918203,18558,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46625,americanliterature.com,13906719,5819,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12142,www.thoughtco.com,13895819,20762,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1618,time.com,13888404,29802,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4472,www.motherjones.com,13842065,29839,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19734,economictimes.indiatimes.com,13783369,35393,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+583,www.newsmax.com,13778303,32708,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14843,www.nzherald.co.nz,13759163,25203,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40629,www.curbsideclassic.com,13690793,3239,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+777,encyclopedia2.thefreedictionary.com,13639218,33901,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69284,www.law.cornell.edu,13614082,10556,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2203,gizmodo.com,13602139,39402,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7389,www.reddit.com,13569928,36402,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2054,www.adweek.com,13563673,50412,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66707,arstechnica.com,13539775,15079,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+77493,www.ola.org,13536823,1538,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34513,www.dumpsteroid.com,13522523,5991,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5114,thehill.com,13485938,25435,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4965,www.dawn.com,13470993,13658,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2712,www.cbr.com,13465935,20577,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1046,www.esquire.com,13456146,22909,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97910,masscases.com,13442570,6204,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18456,www.refinery29.com,13427510,34932,Seungone Kim,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12020,infogalactic.com,13422692,9542,Cole Hunter,FALSE,Weak Moderation,Wiki,General,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92827,bmcgenomics.biomedcentral.com,13421736,2248,Cole Hunter,FALSE,Strong Moderation,Open-Access Scientific Journal,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24048,www.menshealth.com,13406162,28352,Cole Hunter,FALSE,Strong Moderation,Mens Magazine,Social/Lifestyle,,,,Other,Lifestyle magazine,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11073,www.vulture.com,13398520,19100,Cole Hunter,FALSE,Strong Moderation,Entertainment News Website,Entertainment,Social/Lifestyle,,,Other,Lifestyle magazine,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29830,www.newworldencyclopedia.org,13386536,4973,Cole Hunter,FALSE,Strong Moderation,Alternative wiki website,General,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15091,www.cdc.gov,13373820,15438,Cole Hunter,FALSE,Strong Moderation,Government website for disease information,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8338,research.omicsgroup.org,13361612,8776,Cole Hunter,FALSE,Strong Moderation,Open-Access Scientific Journal,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8754,jov.arvojournals.org,13346423,10706,Cole Hunter,FALSE,Strong Moderation,Open-Access Scientific Journal,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3812,www.inc.com,13228006,18370,Cole Hunter,FALSE,Strong Moderation,Business focused magazine website,Business/Finance,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33162,www.machinenoveltranslation.com,13221216,5496,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6575,kotaku.com,13218505,38088,Cole Hunter,FALSE,Strong Moderation,Video Game website and blog,Entertainment,Social/Lifestyle,Reviews,,Other,Video game reviews,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103730,www.thekingdomcollective.com,13215500,2641,Cole Hunter,FALSE,Strong Moderation,Collection of sermon transcripts,Social/Lifestyle,Cultural/Artistic,,,Other,Database of sermons,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16402,mondoweiss.net,13210588,4868,Cole Hunter,FALSE,Strong Moderation,General interest blog,News,,,,Other,News website and blog,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34992,www.buzzfeednews.com,13201098,17489,Cole Hunter,FALSE,Strong Moderation,American news website owned by BuzzFeed,News,Social/Lifestyle,Cultural/Artistic,,Social Media,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4090,forums.newtek.com,13166296,28228,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1094,www.etsy.com,13164447,57416,Cole Hunter,FALSE,Weak Moderation,Ecommerce website focused on handmade/vintage supplies,E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22775,forums.prosportsdaily.com,13163428,9208,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+745,thenextweb.com,13146517,34848,Cole Hunter,FALSE,Strong Moderation,European startup/conference website,Technology/Code,Education/Knowledge,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51929,www.gamespot.com,13087808,26113,Cole Hunter,FALSE,Strong Moderation,Video game news and reviews,Reviews,,,,Other,Video game news,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+81703,luq.lternet.edu,13079869,1726,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5360,www.pubfacts.com,13065174,9868,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37874,kvd8.ru,13045149,2973,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26865,bmchealthservres.biomedcentral.com.preview-live.oscarjournals.springer.com,12995273,2929,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26191,nymag.com,12960610,23538,Cole Hunter,FALSE,Strong Moderation,American culture magazine,News,Social/Lifestyle,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6536,www.rediff.com,12954802,21403,Cole Hunter,FALSE,Strong Moderation,Indian news website ,News,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11407,blogs.msdn.microsoft.com,12882879,27044,Cole Hunter,FALSE,Weak Moderation,Microsoft related blog website (archived),Technology/Code,,,,Other,Archive of technology blog posts,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6576,indianexpress.com,12820584,31367,Cole Hunter,FALSE,Strong Moderation,Indian news website ,News,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+178096,www.state.gov,12774873,3269,Cole Hunter,FALSE,Strong Moderation,US Department of State website,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+207970,transcripts.cnn.com,12732369,2033,Cole Hunter,FALSE,Strong Moderation,CNN transcript database,News,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3040,www.vice.com,12685187,15980,Cole Hunter,FALSE,Strong Moderation,Lifestyle magazine,Social/Lifestyle,Cultural/Artistic,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+187510,wikimili.com,12682364,5739,Cole Hunter,FALSE,Strong Moderation,Wikipedia reader,General,,,,Other,Wikipedia skin for easier reading,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14174,www.imdb.com,12659410,36205,Cole Hunter,FALSE,Strong Moderation,Movie and TV show database,Entertainment,Reviews,Social/Lifestyle,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+236935,getfilings.com,12633803,2441,Cole Hunter,FALSE,Strong Moderation,Database for company financial records,Business/Finance,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26900,liveprayer.com,12567711,3341,Cole Hunter,FALSE,Strong Moderation,Evangelical ministry website,Social/Lifestyle,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+210285,0-bmccancer-biomedcentral-com.brum.beds.ac.uk,12549698,2997,Cole Hunter,FALSE,Strong Moderation,Open-Access scientific journal,Academic,Biomedical/Health,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30778,rarityofficial.com,12545391,5865,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2298,gigaom.com,12544232,16679,Cole Hunter,FALSE,Strong Moderation,Technology analyst firm,Business/Finance,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68283,www.amcostarica.com,12530998,3130,Cole Hunter,FALSE,Strong Moderation,Costa Rican news website,News,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17916,cityimagepress.com,12505032,3126,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19214,file.scirp.org,12458775,4381,Cole Hunter,FALSE,Strong Moderation,Open-Access scientific publisher,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+157315,tractaricurteadearges.ro,12428091,2360,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9279,www.capterra.com,12420174,12551,Cole Hunter,FALSE,Strong Moderation,Software marketplace vendor,E-Commerce,Technology/Code,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9760,www.fodors.com,12379169,22784,Cole Hunter,FALSE,Strong Moderation,Travel guide,Social/Lifestyle,Cultural/Artistic,,,Other,Travel guide,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23278,ludumdare.com,12368923,21414,Cole Hunter,FALSE,Strong Moderation,Game competition website,Entertainment,Social/Lifestyle,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18868,contracts.onecle.com,12351186,7586,Cole Hunter,FALSE,Strong Moderation,Form database,Business/Finance,Government/Policy,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+150067,forums.plentyoffish.com,12346728,6271,Cole Hunter,FALSE,Weak Moderation,Dating website,Social/Lifestyle,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8227,www.nhl.com,12335315,23506,Cole Hunter,FALSE,Strong Moderation,National Hockey League website,Social/Lifestyle,Entertainment,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50806,www.nfl.com,12324951,21972,Cole Hunter,FALSE,Strong Moderation,National Football League website,Social/Lifestyle,Entertainment,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23413,pmg.org.za,12301968,3527,Cole Hunter,FALSE,Strong Moderation,South African parlimentary comitte proceedings ,Government/Policy,,,,Other,Governmental information tracking,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31402,mobile.instructables.com,12296246,12715,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23477,moz.com,12282373,10138,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25144,metro.co.uk,12254211,39265,Cole Hunter,FALSE,Strong Moderation,British news website,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89190,www.scielo.br,12249283,4676,Cole Hunter,FALSE,Strong Moderation,Brazillian open-access publisher,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16620,en.wikiquote.org,12236850,10750,Cole Hunter,FALSE,Strong Moderation,Wiki for quote attribution,General,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+98457,www.superbfurnishings.com,12235247,3490,Cole Hunter,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21686,www.thefreelibrary.com,12233879,7901,Cole Hunter,FALSE,Strong Moderation,"Database of archived journals, magazines, and news stories",General,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40933,ssdmf.info,12218505,900,Cole Hunter,FALSE,Strong Moderation,Public collection of genealogy records,General,,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3759,premium.wpmudev.org,12199844,41879,Cole Hunter,FALSE,Strong Moderation,WordPress dashboard,E-Commerce,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33306,www.bestwestern.fr,12169788,1396,Cole Hunter,FALSE,Strong Moderation,French Best Western company website,E-Commerce,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7674,www.dailystar.co.uk,12163488,45738,Cole Hunter,FALSE,Strong Moderation,British tabloid newspaper,News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17767,www.advocatekhoj.com,12152803,5238,Lj Miranda,FALSE,None,Platform for finding lawyers and advocates in India and getting information on law schools and legal news.,Legal,News,Education/Knowledge,,Other,News and Search Services,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18794,www.houzz.com,12133084,26211,Lj Miranda,FALSE,Weak Moderation,Platform for browsing interior design photos and ideas.,Social/Lifestyle,E-Commerce,,,Other,Seach services ,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6788,www.bostonglobe.com,12129866,18129,Lj Miranda,FALSE,Weak Moderation,News source for New England,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39488,www.justice.gov,12100587,16622,Lj Miranda,FALSE,None,Website for the the United States Department of Justice,Government/Policy,Legal,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+91051,www.opentable.com,12099649,12586,Lj Miranda,FALSE,Weak Moderation,For making online restaurant reservations and reviews,Reviews,E-Commerce,Social/Lifestyle,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26867,obamawhitehouse.archives.gov,12082521,10022,Lj Miranda,FALSE,None,Archival White House website for Obama,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14501,homeguides.sfgate.com,12079382,24152,Lj Miranda,FALSE,None,Magazine for hobbies and weekend activities,Social/Lifestyle,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35389,tv.avclub.com,12073729,9429,Lj Miranda,FALSE,None,Pop culture news and articles,News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+399,www.psychologytoday.com,12019902,10811,Lj Miranda,FALSE,None,"Magazine and news for psychology, behavioral research, relationships, and mental health.",News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10529,www.timeout.com,11972534,39037,Lj Miranda,FALSE,None,Magazine for travel and arts & culture,News,Social/Lifestyle,Cultural/Artistic,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+202142,freethoughtblogs.com,11955531,6775,Lj Miranda,FALSE,Weak Moderation,"Blog platform for freethought writers, focusing on feminism, diversity and against racism and inequity. ",Other,,,Ideologies and thought,Other,Blog platform,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36116,abcnews.go.com,11947913,15897,Lj Miranda,FALSE,None,Website for the news division of the American television network ABC.,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6074,www.homeaway.com,11894657,23146,Lj Miranda,FALSE,None,Redirects to vrbo.com. A rental e-commerce service,E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11377,timesofindia.indiatimes.com,11893643,36983,Lj Miranda,FALSE,None,English-language daily newspaper for India,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37722,jalopnik.com,11884951,30279,Lj Miranda,FALSE,None,Magazine for cars and transportation.,News,Social/Lifestyle,Reviews,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57940,bmccancer.biomedcentral.com,11867058,2852,Lj Miranda,FALSE,Strong Moderation,Open-access journal for cancer research,Biomedical/Health,Academic,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2267,www.yahoo.com,11853818,47785,Lj Miranda,FALSE,None,News and search around the web,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8095,www.businessinsider.com.au,11840230,29670,Lj Miranda,FALSE,None,"Business news on global tech, finance, markets, and strategy.",News,Business/Finance,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+116130,forums.eu.square-enix.com,11839818,18403,Lj Miranda,FALSE,None,Redirects to square-enix-games.com. Website for the game studio Square Enix,Technology/Code,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8511,www.glamour.com,11807263,32858,Lj Miranda,FALSE,None,"Women's newsletter for fashion, entertainment, and wellness.",News,Social/Lifestyle,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+112493,www.architecturalantiques.com,11776716,1995,Lj Miranda,FALSE,None,Website for buying and selling architectural antiques.,E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87222,wdtprs.com,11731009,6492,Lj Miranda,FALSE,Weak Moderation,Blog by Fr. Z containing Christian posts and discussions on what it is to be Catholic in an increasingly difficult age.,Other,,,Religion and Philosophy,Other,Blog,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4636,fortune.com,11715106,24746,Lj Miranda,FALSE,None,"Business newsletter on technology, finance, leadership, and Fortune 500 companies",News,Business/Finance,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18469,www.oreilly.com,11691962,67208,Lj Miranda,FALSE,None,"Company website for the publishing company O'Reilly Media, Inc.",Books,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6867,chroniclingamerica.loc.gov,11687172,31881,Lj Miranda,FALSE,None,Archival website of the Chronicling America collection of the Library of Congress. It contains historic newspaper pages from 1756-1963 or the US Newspaper Directory for newspapers published between 1690-present.,News,Government/Policy,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20132,www.agoda.com,11651739,28754,Lj Miranda,FALSE,Weak Moderation,"Official website of Agoda, an online travel agency that caters to consumers in the Asia-Pacific region.",E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13917,www.deccanherald.com,11581679,33506,Lj Miranda,FALSE,None,An Indian English language daily newspaper published from the Indian state of Karnataka.,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22612,www.bestbuy.com,11574202,13762,Lj Miranda,FALSE,None,"E-commerce website of BestBuy, a multinational consumer electronics retailer.",E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20041,dumpsterbook.com,11563036,5989,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97523,dumpsterblog.com,11557602,5953,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5745,dumpsterfly.com,11552371,5990,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18896,dumpsteramerica.com,11530146,5992,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20961,dumpsterratings.com,11520920,5967,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17749,livedumpster.com,11517323,5994,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79926,dumpsterindex.com,11509171,5995,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21949,ratedumpster.com,11490361,5984,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84899,dumpsterchoice.com,11486158,5952,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24189,wastepages.com,11479934,5987,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11674,dumpsterinfinite.com,11477408,5992,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+599,www.insiderpages.com,11473290,44220,Lj Miranda,FALSE,Weak Moderation,Local search service and recommendation for finding local merchants and businesses,E-Commerce,Reviews,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+912,docs.oracle.com,11457332,16198,Lj Miranda,FALSE,None,Documentation website for Oracle,Technology/Code,,,,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+116417,dumpsterlabs.com,11456249,5992,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+189316,wastereviews.com,11445512,5993,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+131052,wasteadviser.com,11445089,5991,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32286,dumpsterwise.com,11443869,5991,Lj Miranda,FALSE,None,Dumpster rental company for renting short and long-term debris containers.,General,,,Company website and services,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13182,dumpsterzone.com,11435904,5992,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65356,dumpsterwire.com,11435249,5994,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9928,comicvine.gamespot.com,11428824,11725,Lj Miranda,FALSE,Weak Moderation,"Comic database that features Comic reviews, news, and forums.",Entertainment,Cultural/Artistic,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42375,www.brookings.edu,11428726,14142,Lj Miranda,FALSE,None,"Website of the Brookings Institution that conducts independent research for improving policy and governance in the local, national, and global levels.",Government/Policy,Academic,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51319,wasteforge.com,11428721,5950,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+329,maxdumpster.com,11426936,5989,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41029,wasteratings.com,11425162,5984,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11995,royaldumpster.com,11423608,5950,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52013,hbr.org,11418236,9871,Lj Miranda,FALSE,None,"Website for the Harvard Business Review, a magazine by Harvard Business Publishing.",Business/Finance,Academic,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36396,www.intechopen.com,11405243,3865,Lj Miranda,FALSE,None,"Website for IntechOpen, a leading global publisher of Journals and Books in the fields of Science, Technology, and Medicine.",Books,Academic,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44865,ratewaste.com,11395945,5989,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17949,www.haaretz.com,11309218,26392,Lj Miranda,FALSE,None,Israeli newspaper publishing in both Hebrew and English in the Berliner format.,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39757,dumpstercentre.com,11307216,5949,Lj Miranda,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+133597,es.scribd.com,11304977,3800,Lj Miranda,FALSE,Weak Moderation,"Website for Scribd, an American e-book and audiobook subscription services with a miliion titles.",Books,E-Commerce,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11358,www.hrw.org,11291763,6473,Lj Miranda,FALSE,None,"Website for the Human Rights Watch, an international non-goverment organization that conducts research and advocacy on human rights.",Other,,,Human Rights / NGO,Company website,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12976,www.azcentral.com,11275563,17066,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43454,www.gamasutra.com,11268457,15321,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14169,www.tripsavvy.com,11253754,13774,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1188,www.agreatertown.com,11243238,54212,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28725,www.literotica.com,11202113,4760,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24413,www.mercurynews.com,11177886,21776,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+122669,hotswingersclub.com,11118463,5944,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+168129,theblbar.com,11102130,2185,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19785,www.eweek.com,11080248,22013,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+828,leginfo.legislature.ca.gov,11079838,8138,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+894358,pandgs.com,11070482,545,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+81995,www.biggerpockets.com,11055823,10445,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26407,www.ndtv.com,11029281,40367,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5841,emedicine.medscape.com,11021484,4576,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+130744,www.scielo.org.za,11014569,3448,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+900713,info.mzalendo.com,11007194,579,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42701,absolutewrite.com,10969664,9555,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3477,store.cdbaby.com,10925653,30037,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+511,www.digitaljournal.com,10921164,23893,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2531,www.voanews.com,10902504,26132,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51535,www.macworld.com,10844302,19231,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10219,www.villagevoice.com,10826970,22018,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61403,www.huffingtonpost.ca,10821103,20282,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19741,ufdc.ufl.edu,10769372,7858,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15329,www.orlandosentinel.com,10764174,25338,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48056,www.etonline.com,10741597,35070,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38072,www.rottentomatoes.com,10738001,26892,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1879,clintonwhitehouse6.archives.gov,10724526,7750,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76550,consortiumnews.com,10710389,3814,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4774,www.sun-sentinel.com,10703917,20547,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13699,www.consumeraffairs.com,10693567,7904,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69041,www.michaelberger.com,10645523,421,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4223,council.smallwarsjournal.com,10551770,4747,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+427373,q10k.com,10519311,828,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15426,www.jpost.com,10502683,22798,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27586,whyevolutionistrue.wordpress.com,10489645,3772,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9744,www.opendemocracy.net,10488216,9323,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10453,soils.wisc.edu,10483087,11857,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4540,wikivividly.com,10459171,4878,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1647,www.webmd.com,10459035,19747,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19247,sandrarose.com,10427268,5944,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83404,www.houstonchronicle.com,10426400,16367,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36021,www.thenational.ae,10394991,19119,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19078,www.democracynow.org,10370868,8108,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54795,bioone.org,10366527,10561,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42983,v1.escapistmagazine.com,10345155,9851,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5571,www.globenewswire.com,10340813,20120,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+321,www.space.com,10327301,18200,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45373,philmckinney.com,10314741,5577,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30061,www.stargeo.it,10303369,2000,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29142,scholars.duke.edu,10281418,42431,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9997,maps.thefullwiki.org,10279629,5949,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29265,www.infolanka.com,10276173,3484,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1417,www.dallasnews.com,10246658,16615,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84880,www.notebookcheck.net,10243849,10887,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99912,newstechtrend.com,10237369,1335,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3122,in.reuters.com,10179746,30662,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8995,simple.wikipedia.org,10147657,43868,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74372,www.playbabble.com,10144947,2591,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2781,archives.newyorker.com,10133905,14336,Kevin Klyman,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35668,topdocumentaryfilms.com,10128093,2509,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2171,www.sportingnews.com,10097037,25312,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28662,www.seattletimes.com,10086622,18021,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+229391,historichansard.net,10052154,574,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8169,www.complex.com,10049904,42157,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21442,www.dummies.com,10037645,24059,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34043,www.medicalnewstoday.com,10028222,14975,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17307,www.thejournal.ie,10016243,24977,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36646,www.theregister.co.uk,9963821,22255,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43620,www.fao.org,9958130,8997,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+122720,ask.metafilter.com,9955459,5613,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84,venturebeat.com,9947635,19267,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+366909,www.skepticalob.com,9925568,1886,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12479,www.slashfilm.com,9921393,29245,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3056,pubs.rsc.org,9920778,20835,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+222547,www.shtfplan.com,9861236,1909,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2156,grantland.com,9839337,7166,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+591,sputniknews.com,9836001,26332,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7532,www.techrepublic.com,9819516,31864,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92594,archive.constantcontact.com,9817753,11889,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37846,io9.gizmodo.com,9783821,20934,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14466,www.rbth.com,9779365,20248,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83285,shortstories.ucgreat.com,9777875,2947,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15818,traveltips.usatoday.com,9771589,19011,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2482,www.globalsecurity.org,9769111,7976,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4708,www.nme.com,9769065,45721,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5201,www.mtv.com,9756481,23134,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+114698,preferredprint.com,9741683,4963,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5981,www.tripadvisor.com,9733567,53437,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+152364,bibleforums.org,9718962,3513,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+219238,parasitesandvectors.biomedcentral.com,9696549,2316,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6239,www.inverse.com,9691020,20203,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47318,techrights.org,9687586,3761,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39067,www.cambridge.org,9670517,10067,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17355,www.wetcanvas.com,9658217,10987,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66924,www.jimmunol.org,9643686,1985,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12639,www.gearslutz.com,9591429,16999,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13718,succulentsource.com,9575934,5984,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11291,www.computerweekly.com,9550797,19065,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9440,truthout.org,9547389,9797,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+96309,www.philly.com,9528780,13832,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4791,www.reference.com,9519020,51282,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21608,food52.com,9517352,27191,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38272,www.financialexpress.com,9495251,23272,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+215787,californiawetfish.org,9485318,1333,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+321337,www.jneurosci.org,9477889,1516,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39148,listverse.com,9474980,5361,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19670,www.kentucky.com,9474125,22484,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22531,bleacherreport.com,9461531,9923,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14545,www.denverpost.com,9432192,17880,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49325,simplywall.st,9413888,7558,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+335221,www.mvhm.org,9379147,4232,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45051,iovs.arvojournals.org,9357815,11941,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31067,www.telegram.com,9356376,21972,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13876,dumpsterway.com,9349560,4875,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25205,www.dallasobserver.com,9348180,19468,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1219085,www.returnofkings.com,9341924,1041,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+161797,www.asapsports.com,9328803,5118,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27239,www.thefreedictionary.com,9316938,28291,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39947,www.autostraddle.com,9304257,4495,Mohammed Hamdy,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12099,www.musicweb-international.com,9294793,8851,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+145307,joannenova.com.au,9276190,1392,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9999,www.questia.com,9268573,32560,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1476,medical-dictionary.thefreedictionary.com,9267786,25007,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36641,www.nationalreview.com,9237060,12847,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34596,www.lifehack.org,9233513,12544,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+291215,zespec.sokp.pl,9227480,1707,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70860,www.novelall.com,9219370,5339,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7577,www.scp-wiki.net,9212041,10442,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7204,smk-group.ru,9207641,4878,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9082,stackoverflow.com,9197002,30818,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100067,www.ccel.org,9176007,4136,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17379,www.theodysseyonline.com,9173389,14939,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+109396,bmcinfectdis.biomedcentral.com.preview-live.oscarjournals.springer.com,9165962,2902,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+200129,www.marxists.org,9148321,3198,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40542,www.baka-tsuki.org,9139045,2983,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26971,www.paloaltoonline.com,9106003,6939,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4781,www.deseretnews.com,9100054,13325,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24899,archive.org,9081350,14903,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11349,www.chicagobusiness.com,9062147,19741,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+114373,www.thesimpledollar.com,9059515,7341,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+741,www.angieslist.com,9058290,31038,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50481,www.independent.ie,9052068,16814,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10076,brooklynrail.org,9025603,8853,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49125,upge.wn.com,9021001,11800,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16964,www.digitaltrends.com,8992626,16666,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33386,www.indiewire.com,8987514,19195,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44440,www.apnews.com,8981058,31067,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14579,jezebel.com,8972796,24412,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+207110,wacriswell.com,8971484,2423,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26454,www.nps.gov,8948816,17552,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66478,www.counterpunch.org,8911693,7462,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13343,www.teenvogue.com,8900149,23265,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4475,www.geometry.net,8897749,5074,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19224,www.tennis-x.com,8886865,3936,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2066,www.engadget.com,8872634,21671,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22549,www.statscrop.com,8847310,8595,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3462,disneyparksmomspanel.disney.go.com,8842142,51420,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+225074,www.onlinebigbrother.com,8837030,2751,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3198,www.foxsports.com,8835342,22904,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27185,www.universetoday.com,8828802,10687,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20375,www.pocket-lint.com,8821334,15690,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+145999,bmcevolbiol.biomedcentral.com,8819696,1453,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68124,ambergriscaye.com,8816817,8376,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51906,www.wuxiaworld.com,8812153,5853,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44864,www.popularmechanics.com,8808274,15868,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13422,www.scotsman.com,8802194,19300,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+178090,www.amazingfacts.org,8795321,1886,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+188908,lookformedical.com,8787868,2859,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20969,ew.com,8787191,20812,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19050,www.gq.com,8774424,13315,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31679,enacademic.com,8754680,4191,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33974,steemit.com,8752689,21287,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7226,www.bravotv.com,8751211,27488,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6442,www.lonelyplanet.com,8729879,38250,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+108461,www.ukessays.com,8716666,4241,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3046,www.treehugger.com,8714385,25042,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5107,lareviewofbooks.org,8698868,5398,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+227364,gistgear.com,8686628,5652,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+82758,pediatrics.aappublications.org,8683229,3920,Hanlin Li,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29094,www.livestrong.com,8672875,18045,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1869,www.androidpolice.com,8671233,23316,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2846,www.upi.com,8665569,23044,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6868,answers.sap.com,8651345,51484,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3216,www.change.org,8644595,28433,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44893,spie.org,8627647,26544,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+136154,advances.sciencemag.org,8589579,2202,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1362,www.sfchronicle.com,8588900,13431,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38492,forum.mrmoneymustache.com,8588502,3995,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21392,www.shameface.com.wstub.archive.org,8552741,5894,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79025,www.travelandleisure.com,8549541,17387,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12065,www.firstshowing.net,8539895,12639,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+133672,www.pearltrees.com,8517286,10112,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1754,www.sandiegouniontribune.com,8500094,15014,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1865,www.techspot.com,8484661,27477,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+223055,chinacleanenergyinc.com,8467049,893,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18859,hellogiggles.com,8444597,21204,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44144,www.kellyspants.com,8442534,2427,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20536,vmestesmamoy.su,8398879,4409,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5731,www.healthline.com,8393142,9877,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19996,www.thewrap.com,8390596,22439,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9303,www.foodandwine.com,8385649,26207,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25229,www.therebel.media,8384634,8332,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8221,www.chron.com,8384390,16780,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20619,biblehub.com,8379226,14476,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70243,theanarchistlibrary.org,8378616,2609,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+204010,bmcmicrobiol.biomedcentral.com,8377316,1674,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+143544,smresidences.com.ph,8366890,2791,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6500,open.library.ubc.ca,8349402,4210,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+136659,bmcresnotes.biomedcentral.com,8333266,2874,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14423,wn.com,8321610,28671,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1014,www.tweaktown.com,8320099,29742,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27737,www.theage.com.au,8311401,12460,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+719,legal-dictionary.thefreedictionary.com,8263769,22164,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8748,www.thewildlifenews.com,8249974,4290,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41978,www.dw.com,8234740,14122,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11468,ecode360.com,8227776,6215,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2890,www.angelfire.com,8219101,14612,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11671,www.nj.com,8214789,15215,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52572,lifehacker.com,8180396,22573,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56079,www.motherearthnews.com,8176951,8085,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97489,www.scientificamerican.com,8176569,12470,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2172,www.techworld.com,8142461,17820,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9940,ehistory.osu.edu,8119295,19180,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12977,www.lds.org,8111187,13477,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53664,theconservativetreehouse.com,8109015,2387,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18056,www.investopedia.com,8093479,13354,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+147181,www.counter-currents.com,8092290,3740,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+462361,store.vioc.com,8088498,1216,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+110460,www.emptywheel.net,8071938,3530,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32716,bigthink.com,8071370,17077,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+135424,foreignpolicy.com,8066803,7594,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2948,www.news.com.au,8055930,15573,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+130446,www.rationalresponders.com,8026570,3746,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15791,www.ars.usda.gov,8024125,16981,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+94008,www.bodybuilding.com,8015927,7260,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+212743,usa.indettaglio.it,8001048,4824,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88383,karendejo.info,7996841,5436,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+98133,www.prolekare.cz,7987939,1364,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59333,www.dovepress.com,7982130,10318,Emad,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+173230,www.jci.org,7976501,1876,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51663,www.israelnationalnews.com,7971862,20869,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20257,www.answers.com,7969340,9933,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12156,newatlas.com,7968682,16225,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+332074,www.webmastercristiano.com,7959582,1692,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9478,www.syfy.com,7954721,17153,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33803,www.khinsider.com,7948945,7677,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11342,www.dpreview.com,7927646,12978,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45316,pubs.geoscienceworld.org,7926198,11832,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+183162,www.ballroomchicago.com,7926014,449,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+468326,biglistofwebsites.com,7918403,3647,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5525,community.esri.com,7907444,28855,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6321,www.zerohedge.com,7888132,13164,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31412,blogs.seattletimes.com,7885934,24253,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31313,www.freep.com,7858235,14122,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+751255,al-mourabitoun.com,7853923,492,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27608,insecure.archiveofourown.org,7848917,12404,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1364,www.citylab.com,7844924,12237,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44569,datausa.io,7844597,3582,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27772,www.politico.eu,7840502,8561,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25668,thehockeywriters.com,7834306,9270,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28167,www.vogue.com,7807525,22994,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+303086,web.newworldencyclopedia.org,7774719,3226,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+347977,curia.europa.eu,7753729,1417,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9967,themillions.com,7750819,6767,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19401,www.nbcnewyork.com,7743752,22896,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66485,www.tmonews.com,7737669,3215,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21199,www.golfdigest.com,7730872,15028,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+203302,www.theautomaticearth.com,7708670,1959,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4394,www.aanda.org,7704088,4181,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+102435,www.osnews.com,7671698,2519,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13495,ca.reuters.com,7669438,23515,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+113870,lasvegashoteldeals.info,7665689,4459,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3281,novelzec.com,7663050,5814,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2772,www.genealogytoday.com,7657009,9761,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22645,lifestylechic.info,7640880,5254,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4124,www.foodnetwork.com,7632976,33088,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+180219,www.evanmarckatz.com,7630633,1634,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80644,openparliament.ca,7619979,3466,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87353,www.kpubs.org,7613861,2738,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14919,www.jewishworldreview.com,7610449,10758,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36294,www.jsonline.com,7605623,13144,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7331,www.eventbrite.co.uk,7604148,39963,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62406,www.romper.com,7601163,11928,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+351023,www.spacerxstories.com,7599373,605,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22284,www.domainmarket.com,7598546,15439,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+218562,horrorwood.info,7581083,503,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12763,www.simonandschuster.com,7553411,9320,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4238,www.infobarrel.com,7553175,9775,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12480,bugzilla.mozilla.org,7547474,11556,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11667,bra-fitter.info,7545064,3923,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2427,www.lexology.com,7531162,8226,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21143,www.dumpsterator.com,7521945,5975,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1733,www.detroitnews.com,7519963,15873,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5050,www.minnpost.com,7518297,9772,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46965,www.itproportal.com,7511128,20158,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74323,seenmoments.com,7498398,5590,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5582,www.thefader.com,7497748,27218,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9578,bitcointalk.org,7490233,11987,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+382606,bmcbioinformatics.biomedcentral.com,7489430,1598,Manan Dey,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68386,www.eurasiareview.com,7488180,8919,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1757,www.mcall.com,7483837,13914,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14425,www2.deloitte.com,7483725,17193,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5622,www.smashwords.com,7480995,28277,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+147765,www.vialibri.net,7477866,2146,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20588,www.epicurious.com,7477317,12986,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+108116,yaygara.info,7470210,5918,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21459,pitchfork.com,7469633,15016,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1225,amp.pharm.mssm.edu,7465509,4141,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23629,skift.com,7463530,15625,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13397,blogs.sap.com,7462003,11500,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7958,www.sciforums.com,7457673,6183,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23224,interventions.onlinejacc.org,7450815,4532,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18499,elizabethkirke.com,7445519,5891,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50793,amino.com,7437377,11022,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73122,www.unz.com,7435425,2040,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68428,lab101.info,7434522,5881,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7526,www.medicinenet.com,7429909,13246,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52833,www.indystar.com,7416090,12273,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+708,www.thedrive.com,7415027,13201,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3698,www.rxlist.com,7412922,3839,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25945,us.blastingnews.com,7408794,15995,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28521,www.infoq.com,7408163,7896,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99105,www.marksdailyapple.com,7403455,2805,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67374,bmra.org,7391761,5908,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46531,forums.somethingawful.com,7391316,3280,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38882,ledenevipartnery.info,7380348,5737,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+139961,bmcmusculoskeletdisord.biomedcentral.com,7380245,1924,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17498,www.acrwebsite.org,7379612,2145,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1608,kladr.info,7376052,5221,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56530,tcmc-staging.info,7364614,5376,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10509,www.lifewire.com,7358129,9815,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2213,www.dignitymemorial.com,7342492,18246,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1874,www.mnn.com,7340111,14692,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38376,appadvice.com,7331494,34853,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15640,www.meforum.org,7329875,7435,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3915,www.cincinnati.com,7310863,14100,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97980,science.sciencemag.org,7307710,6473,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11926,www.newsday.com,7303079,15272,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41995,www.outsideonline.com,7297053,10655,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+295187,forum.luckymojo.com,7271995,3146,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11641,clutch.co,7259980,4831,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+695,rationalwiki.org,7252700,7464,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+294714,postthreads.org,7241056,1381,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44505,docplayer.net,7234477,9592,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19145,www.rroij.com,7233902,3911,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52612,mtled-novels.com,7230888,5985,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5892,www.mediapost.com,7227181,17659,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30323,www.amsinternational.org,7226132,702,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33912,www.wired.co.uk,7221362,10849,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59221,www.ncronline.org,7221262,9234,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4870,www.audible.co.uk,7219356,11401,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+112949,www.countdownlibrary.com,7218566,1025,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87674,anthonysofwestchester.com,7215176,4891,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23204,members.sailing.org,7210467,14547,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53609,www.iranicaonline.org,7200934,3674,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20031,www.sparkpeople.com,7196797,18399,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24768,www.progarchives.com,7196360,6553,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3902,www.harpersbazaar.com,7179138,19115,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+361630,houkyoubustup.com,7174756,517,Muennighoff,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15614,www.escapistmagazine.com,7165316,17676,Christopher,FALSE,Weak Moderation,"The Escapist is for the mature enthusiast of escapist entertainment. Our readers have grown up with geek and genre entertainment, and have evolved with the tastes of our time. The Escapist is an evolution in online media and community, where geeks of all kinds can watch, read, share, and contribute to everything fun — our guiding reason for being. The Escapist editors are experienced professionals, with years combined working in video games, technology, and entertainment media. Our contributors are industry leaders, veteran video game developers, moviemakers, and blockbusting personalities.",Entertainment,,,,Other,online media,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22159,bioresources.cnr.ncsu.edu,7162871,2019,Christopher,FALSE,Strong Moderation,"Peer-reviewed open-access journal devoted to the science and engineering of lignocellulosic materials, chemicals, and their applications for new uses and new capabilities.",Academic,Education/Knowledge,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51,www.thestudentroom.co.uk,7161158,17100,Christopher,FALSE,Weak Moderation,"The Student Room (TSR) is an online community where thousands of students help each other out. It exists for all young people – no matter your background or your aspirations. Whatever life throws your way, from taking GCSEs to landing a job to dealing with relationships, The Student Room community is here for you.",Social/Lifestyle,Academic,,,Periodicals,online community,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25976,www.business-standard.com,7155251,20729,Christopher,FALSE,None,"Business-standard.com is the online property of Business Standard Private Limited, publisher of India's leading business daily, Business Standard. The website attracts over 15 million unique visitors every month, the highest such number for any standalone business newspaper website in India.",News,Business/Finance,,,Periodicals,online media,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7728,www.ajc.com,7149377,15844,Christopher,TRUE,,,,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58845,www.colombotelegraph.com,7147032,2953,Christopher,FALSE,None,"Colombo Telegraph is strictly a public interest website relating to Sri Lankan matters and is run by a group of exiled journalists. Since its start in 2011, they are working on volunteer basis.",News,,,,Periodicals,non-official news media,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51497,www.pressherald.com,7143163,13754,Christopher,FALSE,None,"The Maine Trust for Local News is the state’s largest network of independent news and media outlets, which together form an essential part of daily life in Maine. With 158 journalists on staff, we serve audiences through our 5 daily newspapers and 17 hyper-local weekly newspapers, in print and online. We cover what matters to Maine, putting a spotlight on issues of vital importance to our people, community and state. The Maine Trust for Local News is a subsidiary of the National Trust for Local News, a non-profit committed to conserving and operating vibrant, sustainable local news enterprises across the country.",News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24378,www.parents.com,7128243,15578,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69106,liveletlive.info,7126167,4928,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93125,www.tor.com,7121854,5651,Christopher,TRUE,,https://reactormag.com,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34869,xconomy.com,7121154,19439,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69078,legalinsurrection.com,7117359,5273,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+143318,www.patentgenius.com,7116887,1565,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46116,allafrica.com,7113137,15967,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5064,do5.b00kmedia.ru,7112911,127189,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1696,www.governing.com,7108804,9793,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+114091,www.paleohacks.com,7108113,8352,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21941,www.marieclaire.com,7101025,17462,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60368,fr.scribd.com,7095153,2410,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7752,www.kansascity.com,7092211,16565,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6298,forum.duolingo.com,7077348,32804,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59384,wol.jw.org,7073038,4584,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22288,www.farmprogress.com,7069756,16608,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32587,anesthesiology.pubs.asahq.org,7067538,7049,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45839,incrediblebihar.info,7064661,5191,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+63281,www.schneier.com,7063721,1881,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55653,www.metro.us,7063602,19470,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59374,www.bedbathandbeyond.com,7055641,28022,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9266,psmag.com,7051093,8244,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12467,www.coursera.org,7050810,11780,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11305,www.radionz.co.nz,7035567,28539,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+204195,arthritis-research.biomedcentral.com,7033651,2185,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+183610,hyperindex.mlpg.co,7021073,1364,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+104215,nutritionfacts.org,7000620,1872,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56499,www.technologyreview.com,6989361,12192,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+168529,hfc.ru,6986793,263,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+137040,www.opednews.com,6965367,10240,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+213893,anythingnovel.com,6962671,4824,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20402,whatareyouupto.org,6956824,5298,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14785,www.smore.com,6954895,20212,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13656,chestofbooks.com,6945499,11448,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84184,www.thetruthaboutguns.com,6942613,2417,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+222936,translational-medicine.biomedcentral.com,6931930,1781,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11695,insideevs.com,6913557,9191,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+242095,japantoday.com,6906299,4743,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21008,www.downtoearth.org.in,6885500,9300,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+549310,www.oldjewstellingjokesonstage.com,6876024,1684,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8353,www.tradebit.com,6874525,11314,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+605393,xn--bibelfralle-yhb.de,6871552,470,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38254,www.aafp.org,6866968,8077,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+198938,zbook.ir,6855695,3781,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39098,avtomatynadengi.info,6842001,4128,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+139234,traveltriangle.com,6832173,9145,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24115,blogs.worldbank.org,6829888,14003,Christopher,FALSE,Strong Moderation,"The World Bank Blogs website contains articles on global issues such as economic inclusion, infrastructure finance, gender equality in development projects, and the impact of technology on development data.",News,Other,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47191,novelonlinefull.com,6823788,4719,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37037,hornywishes.com,6816713,5986,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+307143,rareddit.com,6816267,823,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11791,www.bikeradar.com,6790829,15599,Christopher,FALSE,None,"BikeRadar is the authority on bikes and cycling gear. We have experts testing all types of bikes, parts, clothing and accessories, from road, mountain and gravel to commuting and bikepacking. With more than 15,000 product reviews available at your fingertips, plus loads of advice on maintenance and training, BikeRadar delivers the world’s best cycling advice.",,,,,,Reviews,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+184453,theartmovement.info,6786600,5060,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4594,www.spokesman.com,6776051,15486,Christopher,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8376,southfront.org,6773913,6311,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+118242,www.w3.org,6769473,6242,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60648,www.classicreader.com,6768690,3718,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22707,www.wowhead.com,6761953,9990,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8229,nationalpost.com,6752858,16637,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30642,www.balloon-juice.com,6749779,1842,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57694,www.ddo.com,6747976,7697,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23827,www.edebtconsolidationloans.org,6745201,3329,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+151557,respectfulinsolence.com,6744684,1619,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+78882,restaurantedonpepe.info,6744323,4952,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29569,www.lynda.com,6743748,16514,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21117,www.infogalactic.com,6741228,3880,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+251006,themotherscircle.org,6740748,1082,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+126755,forums.phoenixrising.me,6726509,5541,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70462,m.sandiegoreader.com,6709863,7846,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50232,www.verywellhealth.com,6698238,7955,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+312515,www.wheaty.net,6691663,1892,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61182,www.alliedacademies.org,6690123,4153,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10678,lovefraud.com,6688113,2180,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+242036,theadclubevents.org,6686373,494,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92787,archive.boston.com,6679782,8212,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1778,www.oireachtas.ie,6677186,1904,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19309,thoughtcatalog.com,6673232,9577,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5955,forums.primetimer.com,6671336,3386,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50842,candidkatie.com,6670730,5472,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38229,www.businesswire.com,6664121,14901,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2646,www.courant.com,6660288,11899,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+769,lists.w3.org,6657140,52930,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9089,www.destructoid.com,6655637,14861,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50981,www.viator.com,6646840,17463,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+523,www.brit.co,6642220,16986,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3905,www.biblestudytools.com,6640513,11782,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+370815,wccae.info,6637028,445,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5556,guboards.spokesmanreview.com,6621769,7895,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+167478,www.irs.gov,6618436,3142,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65857,www.theyworkforyou.com,6618066,4327,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18956,pastebin.com,6612855,10735,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40111,www.instyle.com,6612397,21547,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6667,staging.patreon.com,6604051,26334,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83635,uni-watch.com,6602033,1266,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+105068,ogurcy.info,6600133,5972,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41263,local.firestonecompleteautocare.com,6591884,11031,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+104013,www.naturalnews.com,6580443,11661,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69416,en.wikibooks.org,6570273,9419,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+110604,www.al-islam.org,6568073,3572,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9842,scienceblogs.com,6561343,2192,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+149345,vickysands.com,6555494,1377,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39600,www.sooperarticles.com,6549315,10494,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30122,bmcinfectdis.biomedcentral.com,6538615,1868,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3447,megalithic.info,6538387,5970,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22497,www.extremetech.com,6534464,15615,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25076,helpx.adobe.com,6533564,10368,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8799,www.urbandictionary.com,6527041,53709,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8858,www.fixya.com,6524369,11140,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59486,stempublishing.com,6521642,1985,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14700,www.pastemagazine.com,6521296,10357,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+77281,www.billboard.com,6519688,13706,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+95658,thereaderwiki.com,6511303,3529,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3568,bmcplantbiol.biomedcentral.com,6498304,1066,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36027,menupages.com,6488289,9156,Xuhui,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+127294,barbadostoday.bb,6488202,11732,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80815,whatever.scalzi.com,6487387,3033,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47654,www.newscientist.com,6484803,21793,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+352056,udcnyc.com,6484720,1444,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24902,autonovices.info,6479339,5963,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8417,www.faqs.org,6478950,14691,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26219,www.newstatesman.com,6470572,7545,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88828,www.caranddriver.com,6465471,7724,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37074,sports.yahoo.com,6464091,12188,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8565,www.myrecipes.com,6452092,25940,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9,www.ibj.com,6451276,14553,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27703,www.japantimes.co.jp,6440902,12302,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6781,kredittestsiegerjetzde.info,6431259,5110,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+75656,electronicintifada.net,6428455,6939,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18756,forums.soompi.com,6426450,5901,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12273,www.neopets.com,6414018,6776,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19000,www.yourtango.com,6413225,10010,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4420,player.fm,6405196,23380,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65071,depicoteoportenerife.com,6400132,5019,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79714,ideas.repec.org,6397803,9495,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43473,www.essaytown.com,6397652,5018,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46490,www.ncaa.com,6389668,11906,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42943,carkix.com,6387733,3046,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45042,www.genetics.org,6385064,1381,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+257322,voxday.blogspot.com,6375872,1244,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16694,www.ebay.com,6375830,28084,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16314,onlinemedigapinsurance.net,6363215,5993,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46178,coastalwholesales.com,6363138,4682,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23719,www.ato.gov.au,6359822,10424,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+91531,jcb.rupress.org,6354918,1286,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33131,antwerksstudio.com,6354906,5969,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+157524,theimaginativeconservative.org,6349515,3490,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83107,cedar.buffalo.edu,6347886,6021,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43785,www.lawinsider.com,6339438,3554,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27010,en.turkcewiki.org,6333532,3581,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22543,www.marketoracle.co.uk,6333269,5605,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7483,jamanetwork.com,6323811,6154,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+102632,alchetron.com,6317604,5642,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52071,forums.xkcd.com,6309984,4414,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4317,www.kotaku.com.au,6308200,9606,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+165080,outlawvern.com,6302931,1951,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13439,www.austinchronicle.com,6294776,11645,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22673,familypedia.wikia.org,6289169,5787,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+226126,storiesonline.net,6287864,4104,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+86142,www.global-regulation.com,6275665,4315,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21048,voices.washingtonpost.com,6273301,2393,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54296,www.thisdaylive.com,6259533,10371,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21189,oilprice.com,6241103,9845,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7172,parlinfo.aph.gov.au,6238039,9964,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+175795,volokh.com,6237785,2607,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8072,alqaem.us,6231288,5985,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100868,www.strategy-business.com,6227456,3728,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+132346,www.canada.ca,6227452,6259,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34916,permies.com,6224947,4744,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24541,www.mamamia.com.au,6224558,11501,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8774,www.onlinejacc.org,6224526,7293,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29835,myanimelist.net,6224221,10427,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15756,www.librarything.com,6218790,41981,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25056,www.astrotheme.com,6215382,4295,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97569,www.nba.com,6213654,8406,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17751,app-wiringdiagram.herokuapp.com,6211511,47748,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+155513,iomfats.org,6208167,1384,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52566,www.baseballthinkfactory.org,6205942,2601,Deividas Mataciunas,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71732,www.creditconsolidation-usa.com,6203692,5973,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+64370,www.sykescottages.co.uk,6199855,9475,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10400,www.lovebedsheets.com,6198479,3350,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15345,thequietus.com,6197040,8070,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21523,smallbusiness.chron.com,6196102,13002,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2590,forums.storm8.com,6189741,8120,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76336,hitchhikersgui.de,6187669,4163,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5151,www.mondaq.com,6180577,9611,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+405566,bible.org,6175012,2149,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26260,www.euractiv.com,6174386,8722,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5885,www.kobo.com,6174106,29298,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55425,www.soundonsound.com,6165684,4129,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4997,www.ranker.com,6158916,20303,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1119,www.pyramydair.com,6154876,4054,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+272167,cancerres.aacrjournals.org,6154775,1582,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54421,www.ocregister.com,6152348,11812,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+137993,mnogoknigek.info,6148329,5876,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12410,www.itv.com,6148147,22825,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+154210,www.pnas.org,6147459,3221,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11241,www.pajiba.com,6147341,11979,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29386,thereallifechurch.info,6142505,5273,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13203,imaging.onlinejacc.org,6141380,2593,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15991,www.macrumors.com,6140085,10170,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7973,wwa.kiplinger.com,6135807,8537,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3156,idioms.thefreedictionary.com,6132099,24397,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20429,www.campaignlive.co.uk,6131925,16692,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2179,misswinni.org,6129687,2812,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+167728,www.allindianpatents.com,6128039,1722,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33174,prospect.org,6127394,4358,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32685,www.lumberjocks.com,6122672,15217,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55568,www.assignmentpoint.com,6114955,5467,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+268655,www.pepecerezo.com,6110664,260,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13644,www.tennessean.com,6108128,12131,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+181305,www.un.org,6106330,4463,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6851,annals.org,6100569,21828,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32345,eng.kakprosto.ru,6100037,10511,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67332,thewikipost.org,6098539,2646,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31740,zapatosmx.com,6092237,5020,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+355297,strange-in.de,6089576,251,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40588,www.litcharts.com,6087499,9780,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46551,www.template.net,6084606,11309,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+128531,www.mostbeautifullest.com,6082764,691,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59033,www.cntraveler.com,6068228,10794,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2342,www.tampabay.com,6066402,8998,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1463,www.lubbockonline.com,6066268,12922,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15121,www.whiteblaze.net,6061399,5994,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+247620,www.thrivetimeshow.com,6055332,3478,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31844,4archive.org,6048912,5364,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21837,www.molvis.org,6046144,1578,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16899,www.star-telegram.com,6039279,15570,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30023,mrjohal.info,6039249,5183,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+133433,project-shift.org,6039056,2184,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28996,adexchanger.com,6030353,8849,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60758,www.mlive.com,6028982,11413,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61468,www.macworld.co.uk,6024164,12289,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53601,freedomhouse.org,6022185,3587,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42302,www.newsweek.com,6021618,9197,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89500,forums.studentdoctor.net,6021171,8729,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+152527,crookedtimber.org,6002079,1088,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5305,chicago.suntimes.com,5999136,15205,Caroline Shamiso Chitongo,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21532,freetarotreadings.info,5998851,5020,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7338,mirror.uncyc.org,5994652,5714,Da Yin,FALSE,Strong Moderation,A fun encyclopedia platform full of humorous stuffs ,Entertainment,,,,Other,Entertainment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5433,globalvoices.org,5990082,11670,Da Yin,FALSE,None,Platform of sharing global stories that build understanding across borders,Social/Lifestyle,Cultural/Artistic,,,Other,Social/Human rights,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88073,www.joshualandis.com,5985644,1011,Da Yin,FALSE,None,"Blog of Joshua Landis, about Syria politics, history and religion",Cultural/Artistic,Government/Policy,,,Other,Culture/Politics,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26634,theculturetrip.com,5978095,8590,Da Yin,FALSE,None,Travel e-commerce platform offering transportation and hotel packages,E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+215883,oxfordre.com,5975623,2057,Da Yin,FALSE,Strong Moderation,Oxford Research Encyclopedias platform that covers many peer-reviewed trustworthy research,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13476,www.carrentals.com,5964010,11951,Da Yin,FALSE,None,Car rental website,E-Commerce,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14240,www.centralmaine.com,5960194,12900,Da Yin,FALSE,Strong Moderation,Website built by The Maine Trust for Local News,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36650,montessoricentermn.org,5949116,4117,Da Yin,FALSE,None,Website for Montessori Center of Minnesota,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44719,www.ecode360.com,5948538,4418,Da Yin,FALSE,None,"Platform that collects house codified laws and municipal documents which accommodates needs of attorneys, planners, builders etc.",Business/Finance,Legal,,,Other,Law resources,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71718,zh.coursera.org,5933070,10048,Da Yin,FALSE,Weak Moderation,Online course platform,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41284,dulichhaiduong.info,5932641,5667,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70349,es.coursera.org,5928332,10145,Da Yin,FALSE,Weak Moderation,Online course platform,Education/Knowledge,,,,,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+194281,www.religion-online.org,5924467,1650,Da Yin,FALSE,Strong Moderation,Platform for assist teachers and scholars who are interested in exploring religious issues,,,,,Other,Religion,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43841,www.newsflash.org,5924452,5497,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+178618,www.jove.com,5923792,2511,Da Yin,FALSE,Strong Moderation,Platform for collecting videos of laboratory methods and science concepts,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1723,bgr.com,5920368,13931,Da Yin,FALSE,Strong Moderation,Editor reviews about in tech and entertainment,Reviews,Technology/Code,Entertainment,,Other,Editor reviews,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27629,owjn.org,5917402,4252,Da Yin,FALSE,None,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+91541,www4.geometry.net,5916068,5526,Da Yin,FALSE,None,Online learning website that covers e-books across various subjects,Education/Knowledge,Books,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8654,www.gofundme.com,5915526,11599,Da Yin,FALSE,Strong Moderation,Platform for raising money or making a donation,Other,,,Fundraising/Donation,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+86500,weteachenglish.info,5912947,5604,Da Yin,FALSE,None,Website for online English and maths courses,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12598,bugs.launchpad.net,5903652,17177,Da Yin,FALSE,Weak Moderation,Platform for reporting and resolving software bugs,Technology/Code,,,,Other,Technology,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+109441,bmccomplementalternmed.biomedcentral.com,5902549,1476,Da Yin,FALSE,Strong Moderation,"Website for a journal, BMC Complementary Medicine and Therapies",Academic,Biomedical/Health,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62965,www.musicradar.com,5889605,11735,Da Yin,FALSE,None,Website for musicians,Entertainment,Education/Knowledge,,,Other,Music,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37667,sentence.yourdictionary.com,5886184,10731,Da Yin,FALSE,None,English learning website,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18725,www.wehuntedthemammoth.com,5884932,2808,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+354088,www.technets.ca,5880436,257,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+150659,www.realjewnews.com,5873614,655,Da Yin,FALSE,None,Personal blog about the person's opinions ,Cultural/Artistic,,,,Other,Personal blog,FALSE,FALSE,FALSE,FALSE,FALSE,TRUE
+88499,fanfare.metafilter.com,5864711,4520,Da Yin,FALSE,Weak Moderation,"Forum discussing entertainments such as TVs, films",Entertainment,,,,Other,Forum,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65843,www.paperdue.com,5862982,2348,Da Yin,FALSE,None,Website for homework and eassy help,Education/Knowledge,,,,Other,Education,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50563,www.sott.net,5862649,5414,Da Yin,FALSE,Strong Moderation,Website for collecting world's news,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17798,www.howtodothings.com,5861925,11537,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25711,www.nbcwashington.com,5856555,18844,Da Yin,FALSE,Strong Moderation,Website for NBC Washington,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40303,www.eurekastreet.com.au,5855972,4221,Da Yin,FALSE,Strong Moderation,Website for Australian magazine Eureka Street,Books,News,Social/Lifestyle,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25625,mentalfloss.com,5852622,9209,Da Yin,FALSE,None,Platform for collecting interesting facts,Education/Knowledge,,,,Other,Education/Knowledge,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+200,deadspin.com,5847519,14512,Da Yin,FALSE,None,Sports news website,News,Other,,Sports,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43428,www.fosters.com,5846470,13154,Da Yin,FALSE,Strong Moderation,Foster's Daily Democrats website,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+63899,hcgdrops.surfinthespirit.com,5845630,4427,Da Yin,FALSE,None,Advertisement website for HCG Triumph Diet,Biomedical/Health,E-Commerce,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17193,www.getrichslowly.org,5845170,1023,Da Yin,FALSE,None,Providing stories and tips about money management,,,,,Other,Daily tips,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5680,wordpress.org,5845119,29725,Da Yin,FALSE,Weak Moderation,Web publishing system,Technology/Code,,,,Other,Blog system,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26672,www.theforecaster.net,5844019,10425,Da Yin,FALSE,None,Website for Maine State news and media outlets,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103147,alvega.info,5838641,5931,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57270,theartssection.com,5836450,5883,Da Yin,FALSE,Weak Moderation,Platform for photos of indoor furniture,,,,,Other,Furnishment,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7426,www.army.mil,5832798,9711,Da Yin,FALSE,None,U.S. Army website,Government/Policy,,,,Government,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6931,deeaxthesea.com,5832719,5432,Da Yin,FALSE,None,Providing tips about how to restore your site after Google penalties,Technology/Code,,,,Other,Technical tips,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34698,news.yahoo.com,5831810,12429,Da Yin,FALSE,None,Yahoo news website,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+117152,www.cgg.org,5829697,2840,Da Yin,FALSE,None,Website about Christianity and Bible,Cultural/Artistic,,,,Other,Culture,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26331,newburghgazette.com,5826345,4305,Da Yin,FALSE,None,Collecting interesting topics in New York state,General,,,,Other,News collection,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31085,forums.penny-arcade.com,5810876,3920,Da Yin,FALSE,Weak Moderation,Forum about comics,Entertainment,,,,Other,Forum,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49694,www.allure.com,5808583,15719,Da Yin,FALSE,Strong Moderation,Review platform about cosmetics,Reviews,,,,Ecommerce,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8504,bulbapedia.bulbagarden.net,5803914,12371,Da Yin,FALSE,Strong Moderation,Encyclopedia and knowledge base for Pokemon,Entertainment,Education/Knowledge,,,Encyclopedia/Database,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23864,homeownersinsurancediscount.net,5803043,5988,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4266,www.dictionary.com,5800252,32021,Da Yin,FALSE,None,World's leading dictionary,Academic,,,,Academic,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5483,www.catholicculture.org,5792469,5747,Da Yin,FALSE,None,,Cultural/Artistic,,,,Other,Culture,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1787,www.care2.com,5791146,15685,Da Yin,FALSE,Weak Moderation,Petition platform,Government/Policy,Social/Lifestyle,,,Other,Petition,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15399,www.self.com,5781162,11678,Da Yin,FALSE,Strong Moderation,Platform dedicated to enhancing human well-being by providing reviews and tips,Biomedical/Health,Social/Lifestyle,,,Other,Editor reviews/tips,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3245,the.honoluluadvertiser.com,5766394,10440,Da Yin,FALSE,None,Platform for collecting online editions of a newspaper,News,,,,Periodicals,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28691,file770.com,5762153,4109,Da Yin,FALSE,Weak Moderation,Website for fans to discuss Mike Glyer’s science fiction,Books,,,,Other,Forum,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45806,www.chicagonow.com,5758765,8665,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31826,carautoinsurancecomparison.org,5756201,5927,Da Yin,TRUE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18737,www.softwareadvice.com,5744890,6360,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17464,www.indiebound.org,5744406,26811,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+347748,www.fightaging.org,5743560,3097,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93365,comesaua.info,5741691,5483,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3537,www.elsevier.com,5739782,16243,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57118,fr.coursera.org,5738090,9694,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34535,www.cleveland.com,5736960,9354,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+126712,lawlibrary.chanrobles.com,5736054,3206,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18454,www.charlotteobserver.com,5735876,15493,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+119824,balonparado.es,5730644,1893,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85223,www.globalbankingandfinance.com,5729766,10901,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10539,stthomasschool.info,5729118,4886,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49174,www.electricscotland.com,5721966,2744,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+914263,thetourbaby.com,5714514,237,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3615,crtc.gc.ca,5713384,2197,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+109402,www.bookseriesinorder.com,5711458,5366,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+126678,www.wallstreetoasis.com,5704931,5211,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+118019,ndpr.nd.edu,5698517,2399,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4888,grants.nih.gov,5693696,3042,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49698,www.valuewalk.com,5692721,8770,Will Brannon,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17611,forums.gentoo.org,5687906,13181,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+104856,archpaper.com,5676937,7576,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39602,www.seacoastonline.com,5672910,11269,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30161,www.sharewareconnection.com,5670645,9774,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+288711,everything.explained.today,5668848,2228,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13501,www.oregonlive.com,5668394,9304,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93833,planetpov.com,5666911,1967,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+147019,conservativehome.blogs.com,5665963,4812,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19790,forumeiros.info,5664278,5848,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+244635,xtremeinternetmarketing.com,5660032,3235,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34261,poddareshwarrammandir.com,5657601,4908,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5997,www.microsoft.com,5649131,14328,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+102873,www.tabletmag.com,5646083,4880,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24814,townhall.com,5644654,11076,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+296734,live.acbl.org,5637880,982,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+147233,www.bmj.com,5637380,3708,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74880,www.moneygrows.net,5634387,2118,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5544,globalnews.ca,5633185,17308,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+63662,kakzaregistrirovatsja.info,5629861,5369,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37781,goldmarkcity-tnr.info,5605556,5055,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73291,moneymorning.com,5604541,8871,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42912,www.gov.scot,5603084,7670,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24489,www.gamesradar.com,5602332,11234,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41360,ec.europa.eu,5601006,13459,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31337,blogs.lse.ac.uk,5598496,5012,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38169,vdare.com,5596293,10039,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+677347,www.aip.org,5593625,704,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46010,journals.openedition.org,5579758,1181,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66994,forum.prisonplanet.com,5577531,2658,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+96778,georgewbush-whitehouse.archives.gov,5575702,4346,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+541051,www.pwtorch.com,5569988,3657,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14569,dailycaller.com,5568612,17626,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22053,forum.projectcarsgame.com,5561434,7572,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25901,onlinemedicareinsurance.net,5558525,5225,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53189,chocolatelovers.info,5545836,5498,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+107930,archives.legislature.state.oh.us,5544539,1496,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16759,www.futurelearn.com,5543693,8862,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18151,www.finder.com.au,5543501,6040,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+117388,webnovel.online,5542915,5544,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58066,www.orthodoxchristianity.net,5541224,2199,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29485,www.legislation.gov.uk,5540765,10450,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7493,voxeu.org,5536427,6321,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20488,www.askmen.com,5525210,12874,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50175,meownowfl.org,5516612,5436,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60654,www.prevention.com,5508120,16395,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17503,www.slantmagazine.com,5504679,8463,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92047,www.circitor.fr,5503441,4451,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5375,www.loc.gov,5498704,21688,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+107675,strategicstudyindia.blogspot.com,5498081,1398,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+196263,hangtime.blogs.nba.com,5496384,3304,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23062,sabr.org,5489861,2660,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7163,www.nap.edu,5489102,3121,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1785,www.peoplesworld.org,5489066,9942,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+160,pac-12.com,5489035,10852,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8751,oppositelock.kinja.com,5479533,31686,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80337,4chanarchives.com,5476301,5945,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19595,www.spiedigitallibrary.org,5465428,4456,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30675,ru.coursera.org,5453051,9106,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46672,www.dtnpf.com,5449293,9662,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+372986,www.sumobrain.com,5447694,1900,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69305,slideplayer.com,5445344,8974,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14347,www.snewsnet.com,5444549,10999,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38972,www.letsrun.com,5443985,6936,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28965,www.cruisecritic.com,5436459,6396,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+90990,clinicaltrials.gov,5432869,9709,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+90555,nordic.businessinsider.com,5432506,8740,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+419,homestars.com,5430515,51012,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12187,www.newsobserver.com,5429274,13655,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4330,www.resetera.com,5425325,3598,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42369,www.idahostatesman.com,5419349,12506,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+130829,www.gatestoneinstitute.org,5418858,2239,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8088,docs.google.com,5417995,21696,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25235,www.dumbingofage.com,5413804,930,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3990,www.fs.usda.gov,5406269,24801,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+168854,malacats.com,5401290,334,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32670,www.craigmurray.org.uk,5399015,2610,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+156039,www.californiaspecialedlaw.com,5398699,684,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+533135,climateaudit.org,5394670,886,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2748,www.dailydot.com,5394180,10870,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19594,www.livelaw.in,5392588,11377,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2588,www.hotels.com,5389572,35739,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53142,www.congress.gov,5387147,12547,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28567,appleinsider.com,5386824,12677,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37857,www.itbusiness.ca,5383874,9228,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7270,www.expressnews.com,5382934,10061,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19767,www.bicycling.com,5381047,8167,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67749,www.unitedstateszipcodes.org,5380631,11718,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52798,tl.net,5379518,5667,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39237,blogs.discovermagazine.com,5378466,3624,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1329483,hentaiyume.com,5377301,440,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+218275,nstperfume.com,5376790,4317,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39191,www.iqsdirectory.com,5369833,7639,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+279349,www.wildsnow.com,5363307,3217,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99012,www.codeproject.com,5361783,6201,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+82030,www.cato.org,5355328,7133,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+193306,www.history.navy.mil,5353794,4714,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42674,www.neogaf.com,5348556,3019,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+161097,skepchick.org,5348269,3116,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+113858,www.alzheimers.net,5345130,9421,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+414754,marx.libcom.org,5340251,2163,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+143034,encyclopediadramatica.rs,5336168,3900,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+318752,911blogger.com,5335975,5101,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13803,financial-dictionary.thefreedictionary.com,5330068,17289,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44936,pt.coursera.org,5329594,8985,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41349,lawprofessors.typepad.com,5329154,3329,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+153187,ralst.com,5327758,972,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71030,www.madinamerica.com,5320994,1482,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10240,www.inman.com,5320970,15040,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26047,www.creativebloq.com,5315193,8779,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36647,hewan.co,5308918,3033,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50735,mountainx.com,5308185,8337,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25542,www.audible.com.au,5303347,7205,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+125050,dvdmg.com,5298068,2949,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+163129,zh-tw.coursera.org,5297126,9217,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19806,politics.ie,5293952,6403,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24615,fstoppers.com,5292986,7574,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+137686,www.etzion.org.il,5287891,2430,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+287042,wikitravel.org,5287281,3032,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10325,www.hercampus.com,5285748,11792,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1103,aem.asm.org,5283662,1506,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+361154,althouse.blogspot.com,5281163,716,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7481,wtop.com,5279659,15626,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99022,www.realitytvkids.com,5276869,510,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24201,www.visualcv.com,5274514,15846,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+117235,wirednewyork.com,5272319,3172,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28024,www.technobuffalo.com,5270621,13457,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23992,trocaderogastrobar.com,5269988,5388,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21068,www.prweek.com,5266002,15150,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1494,www.irishcentral.com,5261191,11478,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+225380,octavachamberorchestra.com,5258679,884,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11546,www.thecanadianencyclopedia.ca,5257706,7497,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83112,articles.mercola.com,5256952,4325,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26857,pizza.dominos.com,5256396,11884,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38836,www.bellanaija.com,5250206,8977,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+138336,media.wwl.com,5246761,1064,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25046,answers.yahoo.com,5238541,13594,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27202,www.laweekly.com,5234878,10368,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4911,apk-dl.com,5231696,3950,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26945,www.mkrnp.org,5230198,5960,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+476461,www.stonekettle.com,5230096,1580,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+90194,bmcneurosci.biomedcentral.com,5229541,2849,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20503,bible.knowing-jesus.com,5227772,6780,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27168,www.ssa.gov,5223834,3976,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+270964,divxmoviesenglishsubtitles.com,5221958,1318,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7100,www.animallaw.info,5221780,1930,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37088,pinside.com,5215549,8019,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27148,www.renewamerica.com,5212655,5492,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+533397,turka.org.ua,5208135,630,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13264,blogs.ancientfaith.com,5207569,1961,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+401383,emboj.embopress.org,5206936,756,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+916,floridaparcels.com,5203440,3265,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87817,www.lawweb.in,5200050,2371,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100794,thegolfcourselocator.com,5198953,5223,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11354,thediplomat.com,5197249,8511,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99770,www.amazon.com,5196629,7399,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+161982,www.snl.com,5196159,1772,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40428,community.canvaslms.com,5195447,13867,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15580,www.autonews.com,5195346,12735,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+587977,roadhaus.com,5191503,598,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+82088,www.dumpstruction.com,5188347,1994,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93605,www.torta-a-porta.com,5188203,5822,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+310,www.zocdoc.com,5185687,30269,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35270,en.m.wikiquote.org,5184606,3390,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80283,www.newsarama.com,5182638,6020,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34114,www.theurbanlist.com,5181189,11745,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103,www.glassdoor.com,5177322,40524,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35556,www.nbcbayarea.com,5175820,17498,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62063,www.emusician.com,5174966,8058,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58646,www.needlenthread.com,5173667,2528,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33083,kathmandupost.ekantipur.com,5173627,12417,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9473,www.pressreader.com,5172620,12197,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+241207,jcalegacy.com,5169790,724,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+95975,www.seriouseats.com,5164511,9740,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85599,yesichat.com,5163837,5772,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88469,homeinsurancesaver.net,5161655,4850,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60382,wow.gamepedia.com,5161407,11239,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15137,www.ehow.com,5154169,13497,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+171233,virologyj.biomedcentral.com,5146623,1321,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16978,www.stylist.co.uk,5146589,9311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23388,freeform.wfmu.org,5145748,5526,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2169,deeppoliticsforum.com,5144479,3280,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71071,forum.allaboutcircuits.com,5144416,11319,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18755,freedomoutpost.com,5142499,8389,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2281,ohiostatebuckeyes.com,5142093,8072,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3985,www.cosmopolitan.com,5139935,14056,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52979,www.lifehacker.com.au,5137976,9931,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73922,onemileatatime.com,5136123,3751,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31567,www.campgroundreviews.com,5128266,8780,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31605,www.cmswire.com,5118729,9002,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+182614,ja.scribd.com,5116773,2345,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6166,www.wind-watch.org,5113310,11490,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28651,readtiger.com,5109615,3283,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48037,europe.autonews.com,5109469,12758,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24142,www.dma-incorporated.com,5108418,5996,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+323408,www.worldheritage.org,5105981,2195,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21814,www.backcountry.com,5105707,13350,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11013,www.wbez.org,5104552,12961,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+539957,seder-olam.info,5102703,477,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+656326,healthfitnessandbeautyreviews.com,5099085,1745,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32010,www.selfgrowth.com,5098511,7959,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+193179,sensesofcinema.com,5097684,2287,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13327,www.examinerlive.co.uk,5093526,15311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+292058,koalasplayground.com,5087703,1721,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45361,www.piquenewsmagazine.com,5083176,9614,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12836,www.rogerebert.com,5081675,6294,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26624,laitman.com,5081029,5072,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79061,www.news18.com,5075439,14199,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+106063,www.hotrod.com,5074174,6555,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69842,www.monfrague.online,5057725,10225,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7346,www.osha.gov,5057712,5455,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27027,aws.amazon.com,5051307,9549,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32218,sydney.edu.au,5048356,10297,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+81373,www.pprune.org,5038334,4790,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13479,www.dailyxtra.com,5035145,11218,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17162,microbialcellfactories.biomedcentral.com,5028356,942,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5507,splinternews.com,5025763,10792,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4296,unique-news-week.info,5024435,3165,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2637,business.financialpost.com,5021248,9684,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+105002,weei.radio.com,5020950,8583,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+805807,jem.rupress.org,5019247,1206,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13905,observer.com,5011404,8691,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36983,www.vcfed.org,5011300,7863,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22200,med.stanford.edu,5010790,3439,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+118691,patentlyo.com,5009766,1384,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44994,www.wilderssecurity.com,5008007,11041,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66922,www.govtech.com,5006188,7904,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1039,www.msn.com,5004744,12861,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+259584,claudiabrefeld.de,5000910,351,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48083,indyweek.com,4997355,6291,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+207532,m.wikihow.com,4993280,3547,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11316,www.sevendaysvt.com,4984011,7173,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31237,www.everydayhealth.com,4979339,6931,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36502,ticotimes.net,4978615,11108,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+90912,www.mrmoneymustache.com,4969305,527,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24737,latimesblogs.latimes.com,4962040,11448,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9764,m.imdb.com,4960014,13576,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49598,www.borderlandbeat.com,4954850,2618,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6199,blogs.fangraphs.com,4954631,3746,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71478,www.newsbusters.org,4951521,8809,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+334197,www.lawyersgunsmoneyblog.com,4949744,1857,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+335928,oldjewstellingjokesonstage.com,4948991,1169,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74659,de.scribd.com,4948462,2054,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+141057,corporette.com,4947448,900,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88323,www.savannahnow.com,4945121,10229,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+90877,www.thenakedscientists.com,4944025,4886,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+105865,topfamousquotes.com,4943951,5553,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+72986,vacationidea.com,4941134,3065,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51443,theoldtimegospel.com,4941005,1451,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+120016,trixxiecarr.com,4939872,405,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54,www.desmoinesregister.com,4939436,8367,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+111039,coyoteblog.com,4931260,4902,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+182709,asgjesikurdielli.info,4929748,3131,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11220,my.newadvent.org,4917491,2321,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18508,www.vibe.com,4912609,19964,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+154535,the-orbit.net,4911861,2946,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3113,fitsmallbusiness.com,4910031,6440,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16109,uproxx.com,4909947,16954,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4905,www.thebody.com,4908040,8254,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43915,www.therecoveryvillage.com,4905543,6224,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+239902,www.internationalskeptics.com,4903806,2002,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3043,www.insidermonkey.com,4900866,9814,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41106,www.jstage.jst.go.jp,4898753,11908,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+966,findwholelifeinsurance.net,4895731,5287,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41594,www.lybrate.com,4893044,7790,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89567,www.plymouthherald.co.uk,4888367,10457,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2384,www.ebay.co.uk,4887984,11948,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24607,www.e-architect.co.uk,4887330,10493,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39198,wccftech.com,4886669,12453,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37966,www.fulltextarchive.com,4886234,2700,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9699,www.axios.com,4885660,15983,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+123577,iclg.com,4884582,2492,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14952,www.warriorforum.com,4884550,4921,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50641,shanthimandir.missouri.org,4883330,1982,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74076,pjmedia.com,4879478,9241,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+138848,www.bassinsure.com,4876271,309,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41926,www.greaterauckland.org.nz,4872521,1061,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2541,trekmovie.com,4846402,1702,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+64560,patient.info,4845402,4538,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+131121,www.pcper.com,4843905,5511,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3069,clearvisionbiblestudies.com,4843833,1320,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+82167,www.crainsdetroit.com,4841634,10027,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10990,inhabitat.com,4836011,9738,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+77309,www.heritagecremationprovider.com,4834711,5956,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7215,forum.dvdtalk.com,4828563,7720,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+408696,bycommonconsent.com,4825722,1324,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+171592,russianpatents.com,4821848,1210,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31033,www.bikeforums.net,4821659,8675,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+161759,evcilpetim.com,4821232,1384,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+191146,www.lankaweb.com,4815322,3398,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+257282,horsesass.org,4813628,1450,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9345,m.piquenewsmagazine.com,4813244,8837,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+102720,www.eonline.com,4812615,10383,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2703,jobs.theguardian.com,4811179,21345,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+72190,ruscumag.wordpress.com,4811111,2647,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1522,forums.longhaircommunity.com,4810819,4016,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+326149,sunshineday.com,4809502,294,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+283223,bmchealthservres.biomedcentral.com,4807082,1019,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54263,www.runnersworld.com,4805544,7691,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+69375,list.ly,4805199,14583,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+99737,www.greentechmedia.com,4800136,7203,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4267,www.sheknows.com,4799494,11455,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3208,community.hsn.com,4797741,21963,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65173,blogs.mprnews.org,4795941,8518,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4837,www.stabroeknews.com,4792507,9968,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+86029,www.realclimate.org,4789371,1078,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3677,forums.windowscentral.com,4786708,16640,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66804,www.asmscience.org,4786678,2255,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+218580,www.mrpottyrental.com,4781319,4850,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+502273,gssq.blogspot.com,4780355,882,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4543,forums.golfwrx.com,4777902,5391,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+592,www.birminghampost.co.uk,4777364,11369,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+171040,bareactslive.com,4776171,1834,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8516,www.irrawaddy.com,4774036,8628,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+81707,www.halfbakery.com,4773022,9224,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13161,movieweb.com,4770846,11837,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56441,forum.cosmoquest.org,4766206,5053,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24628,cornellsun.com,4765968,7901,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4250,clarity.fm,4763724,12902,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+385638,molecular-cancer.biomedcentral.com,4763157,903,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4135,articles.herald-mail.com,4761837,11006,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+893,job-descriptions.mightyrecruiter.com,4760984,3683,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65676,www.sitepoint.com,4758661,5325,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12499,www.healthcanal.com,4757294,10934,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+123089,bellacaledonia.org.uk,4755656,1933,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14013,www.booksie.com,4753951,7414,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40318,forza-fiume.com,4750778,605,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1391565,timelines.ws,4750358,435,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35297,www.trustedreviews.com,4747894,10643,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+163297,www.in-fisherman.com,4744217,3056,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38292,forums.sherdog.com,4743464,11076,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50987,www.royalroad.com,4739241,1832,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46902,www.juancole.com,4738711,8073,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14276,spark.adobe.com,4735240,8147,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+391325,lawnbowlscentral.com,4733491,645,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22961,www.summitdaily.com,4729531,9794,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16054,www.thelocal.fr,4728235,11486,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+360880,oll.libertyfund.org,4726067,1821,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20794,cheapautoinsuranceonline.org,4725356,5935,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19818,sbcvoices.com,4724408,1353,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1238,clemsontigers.com,4720163,11066,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+179795,www.politifact.com,4717395,7343,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47392,www.conceptart.org,4716177,7973,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44291,www.igi-global.com,4716076,9279,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50216,www.marxist.com,4715617,2256,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89502,www.oneword.com,4713573,5988,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76883,warwick.ac.uk,4709453,11577,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4590,gulfnews.com,4709201,10983,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27003,www.washingtonian.com,4706076,9069,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4722,www.digitalspy.com,4705871,17803,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51664,www.hulldailymail.co.uk,4704357,11029,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23698,www.dailyrecord.co.uk,4701562,11126,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10660,www.marketbeat.com,4697755,6027,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13205,www.healthcentral.com,4695225,9411,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8760,gist.github.com,4688242,11308,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5562,itch.io,4685759,21498,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+166,www.theepochtimes.com,4680427,8987,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88342,www.hockeysfuture.com,4675320,4322,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46711,missliterati.com,4675235,5024,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74184,www.topspeed.com,4674648,5530,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14302,catholicphilly.com,4671135,10232,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+904,www.today.com,4670992,11586,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12184,www.cleanproguttercleaning.com,4669085,3209,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27609,mcb.asm.org,4667459,1022,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30263,spectator.sme.sk,4666441,11205,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16307,wagwalking.com,4665614,7008,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20795,www.prospectmagazine.co.uk,4664936,4082,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16600,www.mckinsey.com,4662741,4449,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65612,www.tellyupdates.com,4662317,5173,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10171,www.cyclingweekly.com,4661167,11674,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20483,postmates.com,4660223,10479,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67819,www.amazon.com.au,4659993,8663,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44948,newsbeezer.com,4659717,9352,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36907,www.govtrack.us,4659444,15116,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21501,www.goal.com,4654690,12022,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50504,washingtonmonthly.com,4650203,10316,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50440,thenationonlineng.net,4649551,9807,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5132,jraeo.com,4648374,5990,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25039,www.audible.ca,4648012,6587,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84022,globicate.com,4644256,5927,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24202,www.livecareer.com,4644108,19974,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+123813,www.speedhunters.com,4643638,2765,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+286116,www.crazydaysandnights.net,4639700,3742,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+185937,ideal-cut-diamond.net,4639332,4916,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79640,christiezdenek.comli.com,4636503,2775,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+102595,www.ilga.gov,4625638,4928,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15411,www.seomoves.co.uk,4618103,5908,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39838,dearauthor.com,4614827,2122,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+427371,www.fertilityiq.com,4606409,1664,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20509,www.eco-business.com,4603872,9039,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+445220,biotechnologyforbiofuels.biomedcentral.com,4603622,789,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21672,www.sermonindex.net,4601412,5072,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+124114,digitallyobsessed.com,4599987,4444,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52442,www.biomedsearch.com,4598653,11826,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25586,www.wsws.org,4598548,4262,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+463071,captainawkward.com,4598134,522,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+95215,www.palestinechronicle.com,4597800,7583,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57808,www.nbcsports.com,4594600,8107,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20635,www.webstagram.biz,4592419,10328,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85928,www.accessgenealogy.com,4591794,5666,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+130405,www.highya.com,4589605,4256,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+438101,www.irunfar.com,4588099,2695,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43716,www.maplandia.com,4586699,11645,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+331461,malariajournal.biomedcentral.com,4586016,1069,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41085,owlcation.com,4584192,2191,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49377,www.all-creatures.org,4583788,9198,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24699,quillette.com,4582301,664,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35708,socialistworker.co.uk,4576937,10475,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16575,thegreenfrog.org,4576482,271,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14058,www.thespruceeats.com,4575494,10613,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67538,www.unigo.com,4573259,6360,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32044,taxguru.in,4566371,4477,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14463,www.gigsalad.com,4565501,18591,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+243669,sortedbybirthdate.com,4564892,1361,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62168,www.responsibletravel.com,4564882,6704,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16829,essaysprofessors.com,4562982,4041,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+243886,mfmultiply.forumotion.com,4560594,1275,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61269,www.hwalibrary.com,4560451,2470,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13972,www.hunker.com,4560433,11366,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1027178,accordingtohoyt.com,4559704,528,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16722,off-guardian.org,4558645,1531,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+395683,www.algen.com,4557768,391,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+682145,www.smoking-mirrors.com,4557221,866,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+169827,www.pinkbike.com,4555849,3497,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35179,homeownersinsuranceonline.net,4555682,5941,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97187,www.derbytelegraph.co.uk,4554228,10784,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26666,www.thenigerianvoice.com,4553743,7539,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10359,cfpub.epa.gov,4552656,15719,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+299594,ebook8.pdfmedia.co,4551853,1743,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1190234,inventinginteractive.com,4549309,609,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49828,www.sacred-texts.com,4546829,2810,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+63350,original.antiwar.com,4546568,4641,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+451113,www.arda.kz,4543482,2187,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+159638,thefederalist.com,4535893,5940,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57269,www.registerguard.com,4535442,8960,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+165337,www.bogleheads.org,4534293,2460,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14522,noisey.vice.com,4533519,6373,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31943,sites.rootsweb.com,4533089,3761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+891205,sftv.org,4523426,393,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+298525,www.shousetsubangbang.com,4522782,965,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28791,www.housepricecrash.co.uk,4522426,5686,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+178213,www.holyspiritspeaks.org,4522159,2311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23258,www.reddeeradvocate.com,4521735,10974,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54060,fasqu.com,4521600,4469,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1573,freia.jp,4521385,4396,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+134512,ichthys.com,4519217,593,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1070262,theoildrum.com,4518068,453,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88310,www.journalofaccountancy.com,4517817,6418,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36425,school-fix-news.info,4514561,3095,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2843,www.rockpapershotgun.com,4509410,8176,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+101403,www.spiegel.de,4505560,3478,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+64929,homeinsurance4cheap.net,4505375,5962,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+81748,trialsjournal.biomedcentral.com,4502194,1253,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88425,www.gameskinny.com,4501763,5701,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+98855,content.time.com,4499968,10796,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36729,www.jacksonville.com,4499337,9354,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+114173,metaglossary.com,4498184,5435,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+371201,www.sociopathworld.com,4496066,1083,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+175576,www.gamerswithjobs.com,4495208,2962,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7477,www.stokesentinel.co.uk,4492495,10890,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97458,www.texas-statutes.com,4489455,2569,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+294205,marginalrevolution.com,4489018,1334,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83990,www.mja.com.au,4487661,4133,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88520,www.healthboards.com,4487608,5487,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59138,www.themoscowtimes.com,4486468,9859,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68559,www.leg.state.fl.us,4486342,5901,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+179716,beta.parliament.scot,4486168,4530,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+250852,fujikawabonsaischool.com,4484516,1618,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15221,www.greeleytribune.com,4482583,10928,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+241502,oklavoters.com,4482140,2023,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13908,study.com,4480576,8353,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+114282,www.oxfordbibliographies.com,4478750,4545,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70902,thno.org,4477671,1158,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43857,www.efilmcritic.com,4477066,4839,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61987,www.thinkadvisor.com,4476142,8191,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49021,semantic.gs,4474474,5493,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100719,adb.anu.edu.au,4474397,5271,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+60577,bikeportland.org,4474114,1692,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+52773,www.tes.com,4473913,13616,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11201,www.greenspun.com,4473067,12162,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97532,www.myantispyware.com,4464165,2874,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+167360,lw2.issarice.com,4463605,1363,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10920,www.vipfaq.com,4461635,5955,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+135417,www.pymnts.com,4458959,10738,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22507,www.cheatsheet.com,4454205,7426,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33110,www.oilandgas360.com,4453854,6716,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34769,www.budgetsaresexy.com,4451844,1658,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30898,www.smartertravel.com,4450728,8175,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43256,ancips2018ranchi.com,4449908,5279,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57127,www.huffingtonpost.in,4449714,8533,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79533,www.boloji.com,4448662,4115,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2950,forum.solidworks.com,4446380,13185,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55293,www.ipsnews.net,4445988,5901,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+261766,www.rd.com,4445565,6976,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+888,www.shutterstock.com,4444573,40745,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57868,hqlo.biomedcentral.com,4438154,1059,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15518,community.spiceworks.com,4436794,13016,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3395,www.gwhatchet.com,4433587,9416,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+95938,www.wisdomjobs.com,4432689,4344,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36732,www.irishexaminer.com,4432120,8726,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54396,dev.to,4431999,6763,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+670853,www.ukpol.co.uk,4429093,1856,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36347,www.producthunt.com,4427803,18505,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45177,www.cliffsnotes.com,4426554,6434,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2107,quizlet.com,4425902,7237,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+509795,markrathbun.blog,4424710,512,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42243,www.mu-43.com,4423560,10638,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+429273,www.nifty.org,4420346,709,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18262,www.abqjournal.com,4413875,8594,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40483,www.frommers.com,4409704,11625,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4227,pamplinmedia.com,4405548,7845,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+198642,www.preceptaustin.org,4404839,561,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+185907,www.babygaga.com,4404003,2999,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4776,tr.coursera.org,4403079,7419,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6659,www.cambridge-news.co.uk,4402984,11303,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+119731,www.russiadefence.net,4397100,1809,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25031,www.northjersey.com,4397083,7824,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28944,scaredmonkeys.net,4397000,3256,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24211,www.texasobserver.org,4390860,5126,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+91941,whc.unesco.org,4389119,4916,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+75368,www.thebalancecareers.com,4388619,6164,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+113243,www.businesstoday.in,4388011,8312,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39296,redmondmag.com,4382717,8289,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47540,0-bmcbiol-biomedcentral-com.brum.beds.ac.uk,4382576,767,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13058,www.crosswalk.com,4381873,6945,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40951,www.guitarplayer.com,4381634,10794,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15156,genius.com,4379934,20401,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+78268,www.stgeorgeutah.com,4379578,6432,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8643,heavy.com,4378086,7406,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38742,thumpertalk.com,4376948,10846,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12332,abc7news.com,4374165,16296,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7230,urbanmilwaukee.com,4370700,7242,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83315,breast-cancer-research.biomedcentral.com,4368997,1483,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40150,forium.co,4368854,2508,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59392,www.torontomike.com,4365734,7972,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93349,www.coupfourandahalf.com,4364673,1176,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+86766,www.health.com,4363177,8828,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19273,www.bellenews.com,4361475,8445,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92263,dissidentvoice.org,4360679,3336,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33963,www.metafusiondesign.com,4359877,5937,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23589,discovermagazine.com,4350598,4815,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73351,thinkprogress.org,4349844,8691,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13567,www.marthastewart.com,4349582,15397,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65368,mooreamusicpele.com,4349025,325,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+119128,www.heritage.org,4348001,2312,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62347,my.wealthyaffiliate.com,4341840,1945,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48282,www.manchestereveningnews.co.uk,4339723,11289,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3634,www.pghcitypaper.com,4339139,8504,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+197159,fogcuripcio.c0.pl,4339114,1963,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25095,www.mariowiki.com,4338953,8811,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+154,film.avclub.com,4337186,5176,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70442,stiveboro.com,4336951,3189,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23097,www.queerty.com,4336701,3952,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13286,www.elle.com,4335534,10986,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8947,wegotthiscovered.com,4334798,11854,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16865,www.dualshockers.com,4329938,14732,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37089,archives.starbulletin.com,4326946,7197,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16249,www.fmylife.com,4325927,9363,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+39440,www.financemagnates.com,4325018,11685,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+72667,www.dezeen.com,4324261,8700,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17338,docs.aws.amazon.com,4321896,12323,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+223136,www.gothamgazette.com,4316269,2996,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36017,bangordailynews.com,4315123,9530,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14650,www.yellowpages.com,4312850,18682,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15375,www.aish.com,4312329,3092,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51609,kgmmvd.org.in,4311245,5704,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+30736,www.devonlive.com,4308348,11034,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36002,www.articlesfactory.com,4307368,10539,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43067,wolfstreet.com,4305325,1530,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+945,www.aarp.org,4305249,6999,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5565,homeinsurancesearch.net,4304694,5973,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21973,www.trustedhousesitters.com,4303190,9001,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47657,www.aspentimes.com,4301755,9180,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37908,www.ajnr.org,4301604,2449,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14395,obrag.org,4301354,4127,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45244,www.blogdesignsbydani.com,4301313,4956,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+259801,www.schaerbeekmr.be,4300868,5247,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1925,travelsimsdirect.com,4298699,5049,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12958,scienmag.com,4298381,9478,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10212,www.sitejabber.com,4297936,11662,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+234315,www.wadeburleson.org,4296656,984,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28631,www.franchising.com,4295181,9584,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56131,www.irishstatutebook.ie,4293670,4714,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+136951,bmcpregnancychildbirth.biomedcentral.com.preview-live.oscarjournals.springer.com,4293473,1010,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+237623,www.warseer.com,4292215,3129,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8942,www.onegreenplanet.org,4289349,7914,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+10029,www.spot.ph,4286525,10266,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3325,newyork.cbslocal.com,4285129,12516,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+432232,news.spbmy.ru,4283030,426,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7464,www.stitcher.com,4281932,28882,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4164,healthyliving.azcentral.com,4280807,9834,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7453,offthekuff.com,4279512,2945,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+200681,implementationscience.biomedcentral.com,4278951,851,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+303816,bmcvetres.biomedcentral.com,4278182,1035,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+234270,thesaker.is,4277129,731,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+64689,www.erowid.org,4277087,4930,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12864,www.ar15.com,4276131,9592,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100090,www.best-car-lease-deals.co.uk,4275235,5535,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+105980,wor.org,4274781,953,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80054,clintonwhitehouse5.archives.gov,4274362,4127,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28993,gamefaqs.gamespot.com,4270896,13026,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25716,www.usmagazine.com,4270175,17244,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80233,www.thespruce.com,4269303,5689,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5323,www.cornwalllive.com,4268397,8703,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59853,www.howtogeek.com,4266747,7013,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+62786,www.gq-magazine.co.uk,4262976,5881,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+545372,www.cisco.com,4258678,3167,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14556,www.siliconrepublic.com,4257957,10603,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14023,www.skysports.com,4255148,9994,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5794,www.nevadaappeal.com,4250191,11076,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32229,blogs.wsj.com,4249774,16827,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36438,www.gardenguides.com,4247752,9713,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3083,www.mid-day.com,4247450,14389,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+143786,blogs.theage.com.au,4240215,1521,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1094653,acecomments.mu.nu,4239003,389,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24084,www.geek.com,4238449,8881,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4489,fabiusmaximus.com,4238101,2098,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25446,www.anandtech.com,4237797,5965,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+125307,www.g3journal.org,4237764,934,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44050,www.newgrounds.com,4237552,27560,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32152,www.mixonline.com,4237407,7666,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2200,www.medgadget.com,4237168,14551,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+87590,www.homeaway.co.uk,4236064,5424,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2381,www.bnd.com,4235635,10709,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58874,latterdaysaintmag.com,4234839,4611,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84677,www.phnompenhpost.com,4233968,11713,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19805,blogs.timesofisrael.com,4233437,5651,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+458775,iai.asm.org,4233069,991,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18475,www.thisweeknews.com,4231530,8761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+92823,www.gloucestershirelive.co.uk,4230636,11420,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23238,www.broadwayworld.com,4230458,9449,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27928,www.taipeitimes.com,4229765,9603,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+311635,www.addicted2decorating.com,4229675,1606,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+54373,www.msnbc.com,4229116,7843,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25797,forums.androidcentral.com,4228388,17445,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+197259,sencanada.ca,4227457,400,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+118267,www.raisethehammer.org,4226073,3069,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+390233,www.jungleredwriters.com,4219426,1519,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20188,www.nanowerk.com,4217164,9070,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12607,insights.dice.com,4212614,7817,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32940,consorziocentrocitta-viareggio.com,4206394,5963,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20118,www.eurogamer.net,4205816,6037,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19004,karensteffano.co.za,4203320,5635,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34964,nordfalcon.com,4202956,3097,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4694,kth.diva-portal.org,4202780,3196,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+192877,therealnews.com,4198872,2933,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32682,www.internetnews.com,4197422,12628,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35283,www.contactmusic.com,4196603,7021,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+130865,wbcat.org,4192990,1829,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+59564,motherboard.vice.com,4192694,6432,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14121,tshaonline.org,4192597,7700,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+49545,seofirepower.com,4191736,5947,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+113199,www.ibm.com,4191202,10186,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45876,www.minecraftforum.net,4188026,6656,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20704,www.nrl.com,4185996,7419,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16099,972mag.com,4185874,2274,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14380,www.pri.org,4183565,8070,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35367,www.ehow.co.uk,4183124,11711,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+227146,www.dcrainmaker.com,4182687,1311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+109173,www.thenewamerican.com,4181155,4716,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36712,guardian.ng,4180173,9191,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32845,www.skyscanner.com,4180153,23668,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+125010,forums.moneysavingexpert.com,4180012,4055,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15832,www.onlineworldofwrestling.com,4179812,2157,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15093,developer.apple.com,4178226,6159,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61684,www.sentinelandenterprise.com,4176335,8869,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+46089,bernews.com,4175463,6992,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38187,www.upcounsel.com,4175000,10757,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+23380,www.espncricinfo.com,4173688,8393,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+322098,www.scoutconnection.com,4172511,808,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+459,news.avclub.com,4171677,18345,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1216791,slamfoo.com,4171162,357,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+967132,3er-schmiede.de,4168691,316,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+226712,binary.choxos.net,4168543,1764,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+179444,jppe.nl,4165319,5770,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26321,www.cheshire-live.co.uk,4165283,13254,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43849,www.rugby.com.au,4159928,10124,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+104911,www.somersetlive.co.uk,4156539,11064,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+88705,wikien3.appspot.com,4156282,2592,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17860,www.redbookmag.com,4154342,9761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103870,www.ibiblio.org,4152123,3508,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1794,www.marriott.com,4152097,16340,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+403627,theseed.info,4151537,1343,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+500934,www.circlecentermall.com,4151053,670,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1080953,mopaintings.com,4149937,281,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5609,meta.wikimedia.org,4149158,6417,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12216,www.riverfronttimes.com,4148867,9895,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4784,classroom.synonym.com,4144930,8965,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58498,5.pdfmedia.co,4140220,1741,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35522,www.phillyvoice.com,4139876,8694,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+160572,mlpg.co,4138152,556,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40225,www.mydr.com.au,4137647,4435,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+156556,www.worldatlas.com,4137586,11401,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+278403,flaglerlive.com,4134341,2830,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+325942,mises.org,4132522,3389,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+105402,www.bigfishgames.com,4128539,3297,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+4756,www.mrdumpsterrental.com,4126951,4961,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1492726,dissectleft.blogspot.com,4126575,607,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21013,kids.kiddle.co,4126540,8905,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85920,www.sportskeeda.com,4125696,9151,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+110517,citec.repec.org,4124775,2126,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14878,www.popxo.com,4122027,8813,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65135,www.rentfinder.co,4121473,5870,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+192750,www.dvdtalk.com,4119542,3145,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70184,www.americamagazine.org,4117513,2757,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25252,cvshome.org,4117376,5918,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26873,www.columbiatribune.com,4112920,9892,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+83769,www.greenbiz.com,4110745,5474,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71276,www.byrdie.com,4108577,5915,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+151291,www.casinocitytimes.com,4106855,9465,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50371,theintercept.com,4104638,3181,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31117,www.nola.com,4103554,6720,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37059,www.gurochan.cx,4101439,2502,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44203,www.gazettelive.co.uk,4100357,11260,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+129414,www.violinist.com,4100267,3839,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3577,www.idgconnect.com,4099896,6391,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+364321,mb-soft.com,4099441,651,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56912,billmoyers.com,4096978,3647,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+9165,cve.circl.lu,4094532,5386,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41864,www.miaminewtimes.com,4093941,8113,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+118437,rsc.byu.edu,4093690,1246,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6990,healthunlocked.com,4089292,4949,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+108040,runnerclick.com,4088246,2307,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+127414,www.insider.co.uk,4088235,11461,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5840,research.chalmers.se,4086873,20185,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17757,www.helpfulgardener.com,4086328,8399,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55741,thepointsguy.com,4083600,4857,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+238135,anthonyflood.com,4083540,610,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+98555,www.democratandchronicle.com,4082977,7058,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+202831,www.btexact.com,4079941,3533,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+41481,www.thesouthafrican.com,4077892,11000,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61717,www.amarillo.com,4077873,10277,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3490,www.kqed.org,4077465,7263,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8930,www.droid-life.com,4076896,18165,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17843,blogs.technet.microsoft.com,4076626,6491,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+122437,verbraucher4teile.de,4075803,319,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+163769,strategie-blog.com,4074989,5957,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2235,www.rfidjournal.com,4073725,7595,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+463,abc7chicago.com,4072141,17535,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11509,www.oecd.org,4071340,9745,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36846,www.techadvisor.co.uk,4071076,8217,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33423,comicsverse.com,4069278,3932,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1157714,genomebiology.biomedcentral.com,4068658,1031,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7094,www.fileguru.com,4067685,8311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13612,www.savingcountrymusic.com,4067467,2008,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11527,www.football.london,4066874,9037,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+85420,www.jewishgen.org,4064849,2384,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40014,startthinkingright.wordpress.com,4059426,2435,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3053,www.emirates247.com,4055687,10746,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19759,www.outlookindia.com,4054230,6696,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+33412,www.brides.com,4051718,9541,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+295389,digital-photography-school.com,4045684,2311,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89191,forums.skadi.net,4042655,4489,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+245708,blackdragonblog.com,4042466,509,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+333831,overland.org.au,4035255,2593,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+183108,www.oatext.com,4033730,1590,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+50783,learn.org,4033583,8071,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+138796,www.rfa.org,4030633,6716,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+80265,www.androidauthority.com,4028594,6731,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+147575,www.early-retirement.org,4028062,4383,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+691751,wn.rsarchive.org,4024716,893,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20728,www.modernghana.com,4024091,11323,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+144966,www.texastribune.org,4024046,5057,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+104872,www.econlib.org,4020783,2195,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70609,lowendmac.com,4020365,3640,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3136,zapier.com,4017476,33114,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+201046,studybay.com,4017369,2612,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+935,bepl.ent.sirsi.net,4017078,7261,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+19006,www.glamourmagazine.co.uk,4016469,9860,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+111085,www.dailytexanonline.com,4015981,7497,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17634,www.coventrytelegraph.net,4014457,11167,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+64584,www.oocities.org,4012516,6126,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103404,www.interviewmagazine.com,4005745,4719,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+267586,www.bmcreview.org,4005525,2089,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+375388,us.cnn.com,4005380,621,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+263157,www.nookl.com,4005347,1189,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+91532,www.leicestermercury.co.uk,4004426,10702,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+5378,fcw.com,4003713,9035,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+197758,psychology.wikia.org,4002422,2686,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+305656,www.platinumhearts.net,4001274,1399,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+121118,liu.diva-portal.org,3998585,3462,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+274992,indoorsoccerliga.de,3993971,776,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57215,maraselgroup.com,3992771,328,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21089,www.freedomplaybypost.com,3992600,2762,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+165291,www.agrochart.com,3991430,2361,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26942,hotair.com,3989595,9186,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+408189,hitchensblog.mailonsunday.co.uk,3988921,955,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+257137,www.airbnb.fr,3985679,3803,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14095,www.eastbaytimes.com,3981395,8111,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13928,www.belfasttelegraph.co.uk,3978430,8979,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15468,www.popsugar.com,3977866,14680,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+641388,usawatchdog.com,3976118,499,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14586,whattheythink.com,3974696,8590,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+280507,masselvik.com,3974513,3352,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+776283,www.themoneyillusion.com,3973555,887,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26937,www.samoaobserver.ws,3972338,9933,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+48575,survivorbb.rapeutation.com,3972075,911,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6048,twinfinite.net,3971184,11626,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3503,www.tate.org.uk,3971164,8092,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+37413,www.meetup.com,3971159,16255,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+103995,awate.com,3969834,701,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44,www.catholic.org,3969806,6009,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+55804,www.building.co.uk,3967669,10900,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+78217,exclusivepapers.com,3966371,3651,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+572358,www.riazhaq.com,3965287,1176,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+144280,oldebible.com,3964287,5421,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45862,ottawacitizen.com,3961681,7519,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+45092,articles.petoskeynews.com,3960173,9746,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70673,www.cheatcc.com,3959574,5640,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+324685,www.wadav.com,3958476,3625,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84136,jneuroinflammation.biomedcentral.com,3951442,751,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17637,git.gnupg.org,3950342,6468,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+63062,www.thenews.com.pk,3950286,9382,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+120062,booktour.tips,3948358,4837,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73592,www.lifesitenews.com,3947662,6761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20460,www.fdic.gov,3946494,5239,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+44121,www.dailypost.co.uk,3946303,11090,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2880,www.familytreemagazine.com,3944799,6880,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57870,edelstar-shop.ru,3944625,2159,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+8235,forums.stickpage.com,3943507,7201,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+108525,jeccr.biomedcentral.com,3943436,937,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+38565,www.thezoereport.com,3943332,13761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53634,www.beeradvocate.com,3942672,4370,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+68957,old.manchesterconfidential.co.uk,3938276,5628,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97462,www.largeformatphotography.info,3938220,4915,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+17882,people.com,3938141,20622,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+6676,www.cruisersforum.com,3936923,6858,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+66043,augustafreepress.com,3936322,8761,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+100278,jmedicalcasereports.biomedcentral.com,3936085,2284,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+75266,www.newstimes.com,3935212,8770,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+175009,www.rehabs.com,3934728,7899,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+329020,www.tcj.com,3933448,1906,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+165884,www.vindy.com,3932389,8413,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+70669,www.tomshardware.com,3928910,4561,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+32336,www.decidio.com,3928137,5508,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+35825,www.t3.com,3925159,6749,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14362,shubertmotors.com,3923507,739,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+109220,www.popmatters.com,3923440,3999,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+927811,americandebtreliefprograms.com,3918423,578,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+520468,gonzaloraffoinfonews.blogspot.com,3915571,923,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+239285,mlca.info,3915464,5915,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73271,m.sevendaysvt.com,3914485,5347,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+47059,www.sciencemag.org,3913759,5503,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+664425,www.truthcommunitychurch.org,3913401,529,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+337358,www.therichest.com,3905360,4199,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+119383,24hourdental.org,3900250,3444,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+205037,lawfilesext.leg.wa.gov,3899292,4245,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+95764,www.hireitpeople.com,3899250,5103,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7217,www.thefamouspeople.com,3897434,4558,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25922,www.aaroads.com,3894914,3772,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+209671,kateharding.net,3891708,593,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+98573,www.technightowl.com,3891295,3447,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89293,wizzley.com,3891245,4630,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84868,www.fhwa.dot.gov,3887081,2517,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+89086,photographylife.com,3886047,1860,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+140107,www.online-literature.com,3883044,2729,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53253,bmw-racer.tk,3882635,1381,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+20417,beebom.com,3881205,6643,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+18687,cupofjo.com,3880868,1109,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56288,www.middletownpress.com,3880555,8561,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13277,clinchem.aaccjnls.org,3878061,1907,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+264622,www.aditighosh.com,3877353,2933,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+192647,www.elephantjournal.com,3874905,4353,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+58551,www.al.com,3868987,6882,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1784541,pointsix.com,3868878,536,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+76970,www.avforums.com,3866750,10397,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+77466,clintonwhitehouse4.archives.gov,3866595,3610,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2471,www.groupon.com,3866547,25035,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+134408,www.transparencymarketresearch.com,3866165,5248,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26860,vietnamnews.vn,3862272,10696,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28112,www.booktopia.com.au,3860680,18841,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74649,gcn.com,3858005,9507,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25567,www.thanhniennews.com,3857089,9670,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+97124,www.wunderstore.co.uk,3856680,2447,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+14663,www.onlineathens.com,3856678,8516,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+94327,www.fda.gov,3856128,4518,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+56560,www.markedbyteachers.com,3850054,3749,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+281556,procar4000.com.ar,3849882,555,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53909,www.cnczone.com,3847732,6623,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7610,toucharcade.com,3847687,10680,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1103656,unlimitedplus.com,3845777,597,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+16619,nesn.com,3842640,12993,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+28537,www.southernliving.com,3842008,9173,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+111891,litreactor.com,3841733,3117,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51815,djbooth.net,3841514,10568,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+36505,nation.com.pk,3841338,10620,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+302,www.asiaone.com,3840765,9059,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+40717,asuraprojects.com,3838251,1140,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+509527,ebooks.adelaide.edu.au,3837635,1097,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+12721,www.thebullsheet.com,3833785,3427,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53581,dcmetrotheaterarts.com,3831940,4624,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11979,www.allaboutjazz.com,3830748,6557,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+231558,surdiamorla.c0.pl,3829516,1971,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+51197,www.shortlist.com,3827463,9728,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29989,www.texasmonthly.com,3825710,4146,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+202254,covermongolia.blogspot.com,3825688,374,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+133036,community.worldheritage.org,3824895,2404,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+67656,www.medindia.net,3823672,11026,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11694,www.indiastudychannel.com,3823441,8574,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+61699,www.itworldcanada.com,3822679,8630,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+73875,webot.org,3822614,3884,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+561390,biblecentre.org,3821181,722,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+75676,www.bibliotecapleyades.net,3821104,1427,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+180481,obatkutilkelaminoriginal.com,3818329,2092,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+194221,nowabikhwan.com,3814987,701,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+11200,www.rappler.com,3814969,7613,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+2973,www.religioustolerance.org,3814746,4690,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+15811,www.clinicaltrials.gov,3812673,7062,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3344,www.centredaily.com,3810754,10742,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3781,www.eugeneweekly.com,3810061,5416,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+532598,www.shamusyoung.com,3807489,510,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+22537,www.geekzone.co.nz,3806911,7105,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+25829,www.cityweekly.net,3806128,5911,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1222,developer.jboss.org,3803705,17581,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+7356,blog.seattlepi.com,3801564,10186,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27405,wmbriggs.com,3801073,1624,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+26212,www.rushlimbaugh.com,3799944,3125,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+27045,www.newindianexpress.com,3798172,10549,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+79797,acklandsgraingernewsletter.com,3797708,316,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24807,freebeacon.com,3796551,7399,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+74226,www.geekwire.com,3795378,8534,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+71179,www.scoop.co.nz,3794210,7615,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+13544,www.epa.gov,3794022,6742,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+3576,www.cso.com.au,3791970,6814,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+93048,www.leafly.com,3790993,9380,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+31874,www.hri.org,3789861,2325,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+21620,www.idownloadblog.com,3789658,10440,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+34,www.surveymonkey.com,3789414,22648,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+53480,scroll.in,3787850,6153,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+65008,feedback.photoshop.com,3786355,11193,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+1962715,music-of-benares.com,3786231,281,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+42523,ramblinwreck.com,3785748,7897,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+29900,www.vrbo.com,3784287,5454,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+57001,www.graphic.com.gh,3784075,8436,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+43083,muse.jhu.edu,3783720,7791,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+84353,www.musicianguide.com,3783498,2193,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+752,www.belfastlive.co.uk,3783211,10966,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE
+24974,propakistani.pk,3782006,8222,,FALSE,,,,,,,,,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE

--- a/src/web_analysis/requirements_website_geolocation.txt
+++ b/src/web_analysis/requirements_website_geolocation.txt
@@ -1,0 +1,6 @@
+pandas
+socket
+IP2Location
+csv
+tqdm
+argparse

--- a/src/web_analysis/website_geolocation.py
+++ b/src/web_analysis/website_geolocation.py
@@ -1,0 +1,150 @@
+import pandas as pd
+import socket
+import IP2Location
+import csv
+from tqdm import tqdm
+import argparse
+
+def get_country(ip_addresses):
+    """
+    Retrieves the country associated with each IP address in a list of domain-IP pairs.
+    Uses the IP2Location database to determine the country.
+
+    Parameters:
+    ip_addresses (list of tuples): List containing tuples of domain and its corresponding IP address.
+
+    Returns:
+    list of tuples: List containing tuples of domain and corresponding country name.
+    """
+    # initialize IP2Location - default db (country level) saved locally at "data/IP2LOCATION-LITE-DB1.IPV6.BIN"
+    ip2location = IP2Location.IP2Location()
+    path_to_db = "data/IP2LOCATION-LITE-DB1.IPV6.BIN"
+    ip2location.open(path_to_db)
+
+    results = []
+    for result in ip_addresses:
+        domain = result[0]
+        ip = result[1]
+        rec = ip2location.get_all(ip)
+        results.append((domain, rec.country_long))
+    return results
+
+def get_ip_from_urls(url_list):
+    """
+    Resolves the IP addresses for a list of URLs and tracks failures.
+
+    Parameters:
+    url_list (list of str): A list of URLs to resolve IP addresses for.
+
+    Returns:
+    tuple (list of tuples, list of str): Returns a tuple containing a list of tuples (each containing a URL and its resolved IP)
+    and a list of URLs that failed to resolve.
+    """
+    ip_addresses = []
+    failed_domains = []
+    
+    for url in tqdm(url_list):
+        try:
+            hostname = url.split("//")[-1].split("/")[0]
+            ip_address = socket.gethostbyname(hostname)
+            ip_addresses.append((url,ip_address))
+        except:
+            # print(f"failed to get ip address for domain: {url}")
+            failed_domains.append(url)
+            
+    return ip_addresses, failed_domains
+
+def get_default_url_list():
+    """
+    Reads a predefined CSV file to get a list of domain names.
+
+    Returns:
+    list of str: Returns a list of domain names extracted from the CSV file.
+    """
+    file_path = 'data/_top_2000_c4_token_and_urlcounts - top_2000_c4_token_and_urlcounts.csv'
+    url_df = pd.read_csv(file_path, usecols=['Domain'])
+    url_list = url_df['Domain'].tolist()
+    return url_list
+
+def read_urls_from_csv(file_path):
+    """
+    Reads URLs from a CSV file assuming no header and URLs in the first column.
+
+    Parameters:
+    file_path (str): Path to the CSV file.
+
+    Returns:
+    list of str: List of URLs read from the CSV file.
+    """
+    url_df = pd.read_csv(file_path, header=None)
+    url_list = url_df.iloc[:, 0].tolist() # URLs must be in the first col with no header
+    return url_list
+
+def save_data(data, 
+              name=None, 
+              nationality_data=True):
+    """
+    Saves the provided data to a CSV file.
+
+    Parameters:
+    data (list of tuples): Data to save (each tuple contains domain and country).
+    name (str, optional): Filename to save the data under. Defaults to 'domain_nationalities.csv' if not specified.
+    nationality_data (bool, optional): If True, includes a header row with 'Domain' and 'Nationality'.
+
+    Returns:
+    None
+    """
+    if name:
+        file_name = 'data/' + name
+    else:
+        file_name = 'data/domain_nationalities.csv'
+
+    with open(file_name, mode='w', newline='', encoding='utf-8') as file:
+        writer = csv.writer(file)
+        if nationality_data == True:
+            writer.writerow(['Domain', 'Nationality'])
+        for row in data:
+            writer.writerow(row)
+    print(f"Successfully saved data to: {file_name}")
+
+def main(args):
+    """
+    Main function to orchestrate the fetching of country data for domains based on URLs or CSV file inputs.
+
+    Parameters:
+    args (Namespace): Command line arguments parsed by argparse.
+
+    Returns:
+    tuple (list of tuples, list of str): Tuple containing list of countries associated with domains and list of domains that failed IP resolution.
+    """
+    if args.url_csv:
+        url_list = read_urls_from_csv(args.url_csv)
+    elif args.custom_url_list:
+        url_list = args.custom_url_list
+    else:
+        url_list = get_default_url_list()
+    
+    ip_addresses, failed_domains = get_ip_from_urls(url_list)
+    print(f"Successfully converted {len(ip_addresses)}/{len(url_list)} domains to IP addresses")
+    
+    countries = get_country(ip_addresses)
+    
+    if args.write_file:
+        save_data(countries)
+    
+    return countries, failed_domains
+
+if __name__ == "__main__":
+    """ 
+    Example commands:
+       - Running the default URL list and writing the output to a file: python website_geolocation.py --write_file
+       - Using a CSV file containing URLs: python website_geolocation.py --url_csv "path/to/your/url_file.csv"
+       - Using a CSV file and writing the output to a file: python website_geolocation.py --url_csv "path/to/your/url_file.csv" --write_file
+       - Specifying a custom list of URLs: python website_geolocation.py --custom_url_list "http://example.com" "http://example.org"
+    """
+    parser = argparse.ArgumentParser(description='Get country data for domains.')
+    parser.add_argument('--custom_url_list', nargs='+', help='Custom URL list to process.')
+    parser.add_argument('--url_csv', type=str, help='Path to a CSV file containing custom URLs to process. URLs must be in the first column with no header')
+    parser.add_argument('--write_file', action='store_true', help='Whether to write the results to a file')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Currently, `website_geolocation.py` uses the domains from `data/_top_2000_c4_token_and_urlcounts - top_2000_c4_token_and_urlcounts.csv` which is stored locally in the data folder. Using custom domains is supported, but I can reconfigure this script to default to a custom domain list if preferred.