### PR TITLE
Multisource licence

### DIFF
--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -8,6 +8,8 @@ collection: null
 license_use: "academic-only"
 # If 1, OpenAI generated data will be included even if license_use would have excluded it
 openai-license-override: 0
+# If 1, GitHub license information will be used if no information (‚undefined‘) is available for our Data Provenance source
+dpi-undefined-license-override: 0
 # 1 means datasets with attribution requirements are fine, 0 excludes them
 license_attribution: 1
 # 1 means datasets with share-alike requirements are fine, 0 excludes them

--- a/src/configs/dpi_github_test.yaml
+++ b/src/configs/dpi_github_test.yaml
@@ -7,11 +7,11 @@ collection: null
 # `academic-only` includes all datasets, even those with academic-only restrictions.
 license_use: "commercial"
 # a list of license sources from where the license information should be retrieved
-license_sources: ["HuggingFace"]
+license_sources: ["DataProvenance", "GitHub"]
 # If 1, OpenAI generated data will be included even if license_use would have excluded it
 openai-license-override: 0
 # If 1, GitHub license information will be used if no information (unspecified) is available for our Data Provenance source
-dpi-undefined-license-override: 0
+dpi-undefined-license-override: 1
 # 1 means datasets with attribution requirements are fine, 0 excludes them
 license_attribution: 1
 # 1 means datasets with share-alike requirements are fine, 0 excludes them

--- a/src/configs/dpi_huggingface_github_test.yaml
+++ b/src/configs/dpi_huggingface_github_test.yaml
@@ -7,7 +7,7 @@ collection: null
 # `academic-only` includes all datasets, even those with academic-only restrictions.
 license_use: "commercial"
 # a list of license sources from where the license information should be retrieved
-license_sources: ["HuggingFace"]
+license_sources: ["DataProvenance", "HuggingFace", "GitHub"]
 # If 1, OpenAI generated data will be included even if license_use would have excluded it
 openai-license-override: 0
 # If 1, GitHub license information will be used if no information (unspecified) is available for our Data Provenance source

--- a/src/configs/huggingface_github_test.yaml
+++ b/src/configs/huggingface_github_test.yaml
@@ -1,0 +1,30 @@
+# The name of a collection in `src/collection_mapper.py` to restrict to
+collection: null
+# Select one of ['commercial', 'unspecified', 'non-commercial', 'academic-only']
+# Where `commercial` includes only commercially licensed datasets, `unspecified`
+# includes commercially licensed or datasets without any found license, `non-commericial`
+# includes commerically licensed, unspecified, and non-commerically licensed datasets.
+# `academic-only` includes all datasets, even those with academic-only restrictions.
+license_use: "academic-only"
+# a list of license sources from where the license information should be retrieved
+license_sources: ["HuggingFace", "GitHub"]
+# If 1, OpenAI generated data will be included even if license_use would have excluded it
+openai-license-override: 0
+# 1 means datasets with attribution requirements are fine, 0 excludes them
+license_attribution: 1
+# 1 means datasets with share-alike requirements are fine, 0 excludes them
+license_sharealike: 1
+# To restrict the number of languages, specify keys or values from `constants/language_groups.json`
+languages: []
+# To restrict the number of languages, specify keys or values from `constants/task_groups.json`
+tasks: []
+# To restrict the number of languages, specify keys or values from `constants/domain_groups.json`
+domains: []
+# Start time as `YYYY-MM-DD`. Excludes datasets created before this time
+start-time: null
+# End time as `YYYY-MM-DD`. Excludes datasets created after this time
+end-time: null
+data-limit: 0
+output-format: "messages" # "messages" or "supervised"
+savedir: "data/"
+# debug: True

--- a/src/configs/huggingface_test.yaml
+++ b/src/configs/huggingface_test.yaml
@@ -1,0 +1,30 @@
+# The name of a collection in `src/collection_mapper.py` to restrict to
+collection: null
+# Select one of ['commercial', 'unspecified', 'non-commercial', 'academic-only']
+# Where `commercial` includes only commercially licensed datasets, `unspecified`
+# includes commercially licensed or datasets without any found license, `non-commericial`
+# includes commerically licensed, unspecified, and non-commerically licensed datasets.
+# `academic-only` includes all datasets, even those with academic-only restrictions.
+license_use: "academic-only"
+# a list of license sources from where the license information should be retrieved
+license_sources: ["HuggingFace"]
+# If 1, OpenAI generated data will be included even if license_use would have excluded it
+openai-license-override: 0
+# 1 means datasets with attribution requirements are fine, 0 excludes them
+license_attribution: 1
+# 1 means datasets with share-alike requirements are fine, 0 excludes them
+license_sharealike: 1
+# To restrict the number of languages, specify keys or values from `constants/language_groups.json`
+languages: []
+# To restrict the number of languages, specify keys or values from `constants/task_groups.json`
+tasks: []
+# To restrict the number of languages, specify keys or values from `constants/domain_groups.json`
+domains: []
+# Start time as `YYYY-MM-DD`. Excludes datasets created before this time
+start-time: null
+# End time as `YYYY-MM-DD`. Excludes datasets created after this time
+end-time: null
+data-limit: 0
+output-format: "messages" # "messages" or "supervised"
+savedir: "data/"
+# debug: True


### PR DESCRIPTION
I have added a new variable to the config file which allows for specifying different license sources (such as HuggingFace or GitHub). Additionally, I have updated the `download_and_filter.py` to incorporate this new feature and have added various filters based on these license sources. Moreover, I added some „rules“ which provide a way to use the license from GitHub if our license (DataProvenance) is "unspecified".