### PR TITLE
Fix Tool-Llama

### DIFF
--- a/src/downloaders.py
+++ b/src/downloaders.py
@@ -863,7 +863,7 @@ def download_tool_llama(accepted_filter_ids):
 
     # The data is distributed as a Google Drive file in the Github readme,
     # rather than via e.g. Huggingface
-    url = "https://docs.google.com/uc"
+    url = "https://drive.usercontent.google.com/download"
     params = {
         "export": "download",
         "id": "1Vis-RxBstXLKC1W1agIQUJNuumPJrrw0",


### PR DESCRIPTION
The dataset (which is a very large zip file) is distributed via Google Drive link, and Google recently started throwing up a "we can't virus-scan this file" page when you request the URL we've been using for it. This breaks our code that uses the dataset.

This PR changes to a different Google download URL that goes to the zip file directly. Tests pass with the test_new_collection.py script.