### PR TITLE
Update license_classes.json

### DIFF
--- a/constants/license_classes.json
+++ b/constants/license_classes.json
@@ -24,6 +24,11 @@
         "1",
         "0"
     ],
+    "Apache 2.0 License":[
+        "All",
+        "1",
+        "0"
+    ],
     "Artistic License 2.0": [
         "All",
         "1",


### PR DESCRIPTION
Error:
```
python src/download_and_filter.py
Config File (src/configs/default.yaml):
  license_use:       academic-only
  openai-license-override:0
  dpi-undefined-license-override:0
  license_attribution:1
  license_sharealike:1
  model-generated:   1
  languages:         []
  tasks:             []
  domains:           []
  data-limit:        0
  output-format:     messages
  savedir:           data/
Defaults:
  --licenses:        []
  --license_sources: ['DataProvenance']
  --text-sources:    

Traceback (most recent call last):
  File "/home/ahmadanis/Data-Provenance-Collection/src/download_and_filter.py", line 250, in <module>
    main(args)
  File "/home/ahmadanis/Data-Provenance-Collection/src/download_and_filter.py", line 52, in main
    data_summary = filters.map_license_criteria(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmadanis/Data-Provenance-Collection/src/helpers/filters.py", line 101, in map_license_criteria
    ours_resolved[uid] = classify_and_resolve_licenses(our_uid_to_license_infos[uid], all_constants)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmadanis/Data-Provenance-Collection/src/helpers/filters.py", line 93, in classify_and_resolve_licenses
    classifications = classify_license(license_name, license_url, all_constants)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmadanis/Data-Provenance-Collection/src/helpers/filters.py", line 15, in classify_license
    use_case, attribution, share_alike = all_constants["LICENSE_CLASSES"][license_name]
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'Apache 2.0 License'
```

In some places, we are using "Apache 2.0 License" and in some places, we are using "Apache License 2.0".