### PR TITLE
Add Reasoning

### DIFF
--- a/constants/creator_groups.json
+++ b/constants/creator_groups.json
@@ -526,6 +526,7 @@
         "Lanfrica",
         "Rupert",
         "SIL International",
+        "SkunkworksAI",
         "TRoboto",
         "The British Library",
         "Tidrael",

--- a/constants/data_formats.json
+++ b/constants/data_formats.json
@@ -3,6 +3,7 @@
     "Few-shot",
     "Chain-of-Thought",
     "Program-of-Thought",
+    "Multi-step Reasoning",
     "Multi-turn Dialog",
     "Program of Thoughts",
     "Response Ranking"

--- a/data_summaries/Reasoning.json
+++ b/data_summaries/Reasoning.json
@@ -1,0 +1,52 @@
+{
+    "Reasoning-0.01 ": {
+        "Unique Dataset Identifier": "reasoning-0.01",
+        "Dataset Name": "reasoning-0.01",
+        "Paper Title": "",
+        "Dataset URL": "https://huggingface.co/datasets/SkunkworksAI/reasoning-0.01",
+        "GitHub URL": "",
+        "Hugging Face URL": "https://huggingface.co/datasets/SkunkworksAI/reasoning-0.01",
+        "Papers with Code URL": "",
+        "ArXiv URL": "",
+        "Semantic Scholar Corpus ID": "",
+        "Collection": "Reasoning",
+        "Collection URL": "https://huggingface.co/datasets/SkunkworksAI/reasoning-0.01",
+        "Languages": [
+            "English"
+        ],
+        "Task Categories": [
+            "Algebraic Expression Evaluation",
+            "Coding",
+            "Code Synthesis",
+            "Commonsense Reasoning",
+            "Instruction Following",
+            "Logical Reasoning",
+            "Logical and Mathematical Reasoning",
+            "Logical Reasoning Question Answering",
+            "Math",
+            "Program Synthesis"
+        ],
+        "Text Sources": [],
+        "Model Generated": [],
+        "Format": [
+            "Multi-step Reasoning"
+        ],
+        "Human Annotation": "No",
+        "Derived from Datasets": [],
+        "Creators": [
+            "SkunkworksAI"
+        ],
+        "Licenses": [
+            {
+                "License": "Apache License 2.0",
+                "License URL": "https://huggingface.co/datasets/SkunkworksAI/reasoning-0.01"
+            }
+        ],
+        "License Notes": "",
+        "License Verified By": "Mohammed Hamdy",
+        "Dataset Filter IDs": [
+            "reasoning-0.01"
+        ],
+        "Bibtex": ""
+    }
+}

--- a/data_summaries/Reasoning.json
+++ b/data_summaries/Reasoning.json
@@ -1,5 +1,5 @@
 {
-    "Reasoning-0.01 ": {
+    "reasoning-0.01": {
         "Unique Dataset Identifier": "reasoning-0.01",
         "Dataset Name": "reasoning-0.01",
         "Paper Title": "",

--- a/src/collection_mapper.py
+++ b/src/collection_mapper.py
@@ -394,6 +394,10 @@ COLLECTION_FN_MAPPER = {
         "download_function": downloaders.download_conifer,
         "prepare_function": preparers.prepare_conifer,
     },
+    "Reasoning": {
+        "download_function": downloaders.download_reasoning,
+        "prepare_function": preparers.prepare_reasoning,
+    },
     "DialogStudio": {
         "download_function": downloaders.download_dialogstudio,
         "prepare_function": preparers.prepare_dialogstudio,

--- a/src/downloaders.py
+++ b/src/downloaders.py
@@ -1348,6 +1348,9 @@ def download_conifer(accepted_filter_ids):
     dset = huggingface_download("ConiferLM/Conifer", split="train_sft")
     return dset
 
+def download_reasoning(accepted_filter_ids):
+    dset = huggingface_download("SkunkworksAI/reasoning-0.01", split="train")
+    return dset
 
 def download_dialogstudio(accepted_filter_ids):
     dsets = []

--- a/src/preparers.py
+++ b/src/preparers.py
@@ -1462,6 +1462,13 @@ def prepare_conifer(row):
         parent = i
     return messages
 
+def prepare_reasoning(row):
+    outputs = "\n".join([row["reasoning"], row["output"]]).strip()
+    return convert_inputs_targets_to_messages(
+        row["instruction"],
+        outputs,
+        "reasoning-0.01",
+    )
 
 def prepare_dialogstudio(row):
     conversation = row["log"]


### PR DESCRIPTION
This PR adds SkunkworksAI's reasoning-0.01 (with the downloader, preparer, and mapper). All tests passed successfully.

**Note**: There seems to be no provided information about how the dataset was created (probably still WIP). No publications, No info in the dataset card, No info in [X announcement](https://x.com/skunkworks_ai/status/1809281730114703496), and the question about [which model was used](https://huggingface.co/datasets/SkunkworksAI/reasoning-0.01/discussions/5) is still not answered in the HF repo discussion. We can add this info once they are provided in the future.
