### PR TITLE
Add Glaive code assistant v2 and v3

### DIFF
--- a/data_summaries/Glaive Code Assistant v2.json
+++ b/data_summaries/Glaive Code Assistant v2.json
@@ -1,0 +1,53 @@
+{
+    "glaive-code-assistant-v2": {
+        "Unique Dataset Identifier": "glaive-code-assistant-v2",
+        "Dataset Name": "glaive-code-assistant-v2",
+        "Paper Title": "",
+        "Dataset URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v2",
+        "GitHub URL": "",
+        "Hugging Face URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v2",
+        "Papers with Code URL": "",
+        "ArXiv URL": "",
+        "Semantic Scholar Corpus ID": "",
+        "Collection": "Glaive Code Assistant v2",
+        "Collection URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v2",
+        "Languages": [
+            "English",
+            "Code"
+        ],
+        "Task Categories": [
+            "Code",
+            "Coding",
+            "Code Generation",
+            "Code Synthesis",
+            "C++ Program Synthesis",
+            "Instruction Following",
+            "Program Synthesis",
+            "Text to Code"
+        ],
+        "Text Sources": [],
+        "Model Generated": [
+            "In-House Glaive AI"
+        ],
+        "Format": [
+            "Zero-shot"
+        ],
+        "Human Annotation": "No",
+        "Derived from Datasets": [],
+        "Creators": [
+            "Glaive AI"
+        ],
+        "Licenses": [
+            {
+                "License": "Apache License 2.0",
+                "License URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v2"
+            }
+        ],
+        "License Notes": "",
+        "License Verified By": "Mohammed Hamdy",
+        "Dataset Filter IDs": [
+            "glaive-code-assistant-v2"
+        ],
+        "Bibtex": ""
+    }
+}

--- a/data_summaries/Glaive Code Assistant v3.json
+++ b/data_summaries/Glaive Code Assistant v3.json
@@ -1,0 +1,53 @@
+{
+    "glaive-code-assistant-v3": {
+        "Unique Dataset Identifier": "glaive-code-assistant-v3",
+        "Dataset Name": "glaive-code-assistant-v3",
+        "Paper Title": "",
+        "Dataset URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3",
+        "GitHub URL": "",
+        "Hugging Face URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3",
+        "Papers with Code URL": "",
+        "ArXiv URL": "",
+        "Semantic Scholar Corpus ID": "",
+        "Collection": "Glaive Code Assistant v3",
+        "Collection URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3",
+        "Languages": [
+            "English",
+            "Code"
+        ],
+        "Task Categories": [
+            "Code",
+            "Coding",
+            "Code Generation",
+            "Code Synthesis",
+            "C++ Program Synthesis",
+            "Instruction Following",
+            "Program Synthesis",
+            "Text to Code"
+        ],
+        "Text Sources": [],
+        "Model Generated": [
+            "In-House Glaive AI"
+        ],
+        "Format": [
+            "Zero-shot"
+        ],
+        "Human Annotation": "No",
+        "Derived from Datasets": [],
+        "Creators": [
+            "Glaive AI"
+        ],
+        "Licenses": [
+            {
+                "License": "Apache License 2.0",
+                "License URL": "https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3"
+            }
+        ],
+        "License Notes": "",
+        "License Verified By": "Mohammed Hamdy",
+        "Dataset Filter IDs": [
+            "glaive-code-assistant-v3"
+        ],
+        "Bibtex": ""
+    }
+}

--- a/src/collection_mapper.py
+++ b/src/collection_mapper.py
@@ -97,6 +97,14 @@ COLLECTION_FN_MAPPER = {
         "download_function": downloaders.download_glaive_code_assistant,
         "prepare_function": preparers.prepare_glaive_code_assistant,
     },
+    "Glaive Code Assistant v2": {
+        "download_function": downloaders.download_glaive_code_assistant_v2,
+        "prepare_function": preparers.prepare_glaive_code_assistant_v2,
+    },
+    "Glaive Code Assistant v3": {
+        "download_function": downloaders.download_glaive_code_assistant_v3,
+        "prepare_function": preparers.prepare_glaive_code_assistant_v3,
+    },
     "Nectar": {
         "download_function": downloaders.download_nectar,
         "prepare_function": preparers.prepare_nectar,

--- a/src/downloaders.py
+++ b/src/downloaders.py
@@ -289,6 +289,14 @@ def download_glaive_code_assistant(accepted_filter_ids):
     return huggingface_download('glaiveai/glaive-code-assistant', split='train')
 
 
+def download_glaive_code_assistant_v2(accepted_filter_ids):
+    return huggingface_download("glaiveai/glaive-code-assistant-v2", split='train')
+
+
+def download_glaive_code_assistant_v3(accepted_filter_ids):
+    return huggingface_download("glaiveai/glaive-code-assistant-v3", split='train')
+
+
 def download_thai_gen_ai_alpaca(accepted_filter_ids):
     return huggingface_download("Thaweewat/alpaca-cleaned-52k-th", split="train")
 

--- a/src/preparers.py
+++ b/src/preparers.py
@@ -619,6 +619,22 @@ def prepare_glaive_code_assistant(row):
     )
 
 
+def prepare_glaive_code_assistant_v2(row):
+    return convert_inputs_targets_to_messages(
+        row["question"],
+        row["answer"],
+        "glaive-code-assistant-v2",
+    )
+
+
+def prepare_glaive_code_assistant_v3(row):
+    return convert_inputs_targets_to_messages(
+        row["question"],
+        row["answer"],
+        "glaive-code-assistant-v3",
+    )
+
+
 def prepare_hc3(row, lang):
     # dset_id = f"hc3_{lang}-{row['source']}"
     messages = [


### PR DESCRIPTION
This PR adds Glaive's code assistant v2 and v3. No information was given about the details of creating the dataset except that it was generated using Glaive's in-house data generation pipeline [here](https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v2/discussions/6) and [here](https://huggingface.co/datasets/glaiveai/glaive-code-assistant-v3/discussions/2). 